### PR TITLE
Minor fix suggested in Recommenders repo

### DIFF
--- a/utils_nlp/dataset/url_utils.py
+++ b/utils_nlp/dataset/url_utils.py
@@ -35,7 +35,7 @@ def maybe_download(
         r = requests.get(url, stream=True)
         total_size = int(r.headers.get("content-length", 0))
         block_size = 1024
-        num_iterables = math.ceil(total_size // block_size)
+        num_iterables = math.ceil(total_size / block_size)
 
         with open(filepath, "wb") as file:
             for data in tqdm(


### PR DESCRIPTION
Update floor division to division based on the comment received in Recommenders repo. 

> no, using math is fine, but the // operator does integer division which will round down (10 // 3 = 3), so the ceil is not actually doing anything. but if you do (10 / 3 = 3.333) then apply ceil you will get 4 which is what I'm assuming you want.

https://github.com/microsoft/recommenders/pull/813#issuecomment-499497096