### PR TITLE
sts-benchmark data loader fix

### DIFF
--- a/utils_nlp/dataset/stsbenchmark.py
+++ b/utils_nlp/dataset/stsbenchmark.py
@@ -76,14 +76,34 @@ def _load_sts(src_file_path):
     Args:
         src_file_path (str): filepath to train/dev/test csv files.
     """
-    with open(src_file_path, 'r', encoding="utf-8") as f:
+    with open(src_file_path, "r", encoding="utf-8") as f:
         sent_pairs = []
         for line in f:
             l = line.strip().split("\t")
-            sent_pairs.append([l[0].strip(), l[1].strip(), l[2].strip(), l[3].strip(), float(l[4]), l[5].strip(),
-                               l[6].strip()])
+            sent_pairs.append(
+                [
+                    l[0].strip(),
+                    l[1].strip(),
+                    l[2].strip(),
+                    l[3].strip(),
+                    float(l[4]),
+                    l[5].strip(),
+                    l[6].strip(),
+                ]
+            )
 
-        sdf = pd.DataFrame(sent_pairs, columns=["column_0", "column_1", "column_2", "column_3", "column_4", "column_5", "column_6"])
+        sdf = pd.DataFrame(
+            sent_pairs,
+            columns=[
+                "column_0",
+                "column_1",
+                "column_2",
+                "column_3",
+                "column_4",
+                "column_5",
+                "column_6",
+            ],
+        )
         return sdf
 
 
@@ -93,6 +113,15 @@ def clean_sts(df):
     Args:
         df (pandas.Dataframe): drop columns from train/test/dev files.
     """
-    clean_df = df.drop(["column_0", "column_1", "column_2", "column_3"], axis=1)
-    clean_df = clean_df.rename(index=str, columns={"column_4": "score", "column_5": "sentence1", "column_6": "sentence2"})
+    clean_df = df.drop(
+        ["column_0", "column_1", "column_2", "column_3"], axis=1
+    )
+    clean_df = clean_df.rename(
+        index=str,
+        columns={
+            "column_4": "score",
+            "column_5": "sentence1",
+            "column_6": "sentence2",
+        },
+    )
     return clean_df


### PR DESCRIPTION
### Description
read_csv() from pandas causes skipping rows with extra tabs in the row
and auto_read_file() creates extra columns in the dataflow object 

Therefore, reading file line by line stripping tabs and then creating a new pandas df from it. Preventing skipping rows

### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project, as detailed in our [contribution guidelines](../CONTRIBUTING.md).
- [ ] I have added tests.
- [ ] I have updated the documentation accordingly.



