### PR TITLE
Sts benchmark fix

### DIFF
--- a/scenarios/data_prep/README.md
+++ b/scenarios/data_prep/README.md
@@ -25,7 +25,7 @@
 				<a href="http://ixa2.si.ehu.es/stswiki/index.php/STSbenchmark">STS Benchmark</a>
 			</td>
 			<td>
-				<a href="stsbenchmark.ipynb">sts_load.ipynb</a>
+				<a href="stsbenchmark.ipynb">stsbenchmark.ipynb</a>
 			</td>
 			<td>Downloads and cleans the STS Benchmark dataset. Shows an example of tokenizing and removing stopwords using the popular <a href="https://spacy.io/">spaCy</a> library.</td>
 		</tr>
@@ -34,7 +34,7 @@
 				<a href="https://www.microsoft.com/en-us/download/details.aspx?id=52398">MSR Paraphrase Corpus</a>
 			</td>
 			<td>
-				<a href="msrpc.ipynb">msrpc_load.ipynb</a>
+				<a href="msrpc.ipynb">msrpc.ipynb</a>
 			</td>
 			<td>Download and clean the MSR Paraphrase corpus.</td>
 		</tr>

--- a/scenarios/data_prep/stsbenchmark.ipynb
+++ b/scenarios/data_prep/stsbenchmark.ipynb
@@ -46,7 +46,7 @@
    "source": [
     "import sys\n",
     "\n",
-    "sys.path.append(\"../../../\")  ## set the environment path\n",
+    "sys.path.append(\"../../\")  ## set the environment path\n",
     "\n",
     "import os\n",
     "import azureml.dataprep as dp\n",
@@ -67,7 +67,7 @@
    "outputs": [],
    "source": [
     "STS_URL = \"http://ixa2.si.ehu.es/stswiki/images/4/48/Stsbenchmark.tar.gz\"\n",
-    "BASE_DATA_PATH = \"../../../data\"\n",
+    "BASE_DATA_PATH = \"../../data\"\n",
     "RAW_DATA_PATH = os.path.join(BASE_DATA_PATH, \"raw\")\n",
     "CLEAN_DATA_PATH = os.path.join(BASE_DATA_PATH, \"clean\")"
    ]
@@ -76,14 +76,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 01 Data Download"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Make a directory for the data if it doesn't already exist, and then download."
+    "### 01 Data Download\n",
+    "In this section we \n",
+    "* load raw data into a dataframe\n",
+    "* peek into the first 5 rows"
    ]
   },
   {
@@ -100,68 +96,21 @@
    "cell_type": "code",
    "execution_count": 4,
    "metadata": {},
-   "outputs": [],
-   "source": [
-    "def download_sts(url, dirpath):\n",
-    "    zipfile = maybe_download(url, work_directory=dirpath)\n",
-    "    unzipped = stsbenchmark._extract_sts(zipfile, target_dirpath=dirpath, tmode=\"r:gz\")\n",
-    "    return zipfile, unzipped"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "418kB [00:03, 138kB/s]                             "
+      "100%|██████████| 401/401 [00:01<00:00, 310KB/s]  \n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Data downloaded to ../../../data/raw/stsbenchmark\n"
+      "Data downloaded to ../../data/raw/raw/stsbenchmark\n"
      ]
     },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n"
-     ]
-    }
-   ],
-   "source": [
-    "tarfile, datapath = download_sts(STS_URL, RAW_DATA_PATH)\n",
-    "print(\"Data downloaded to {}\".format(datapath))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### 02 Data Understanding\n",
-    "In this section we \n",
-    "* load raw data into a dataframe\n",
-    "* peek into the first 10 rows"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "We can load the data using a `read` function that has built-in automatic filetype inference:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {},
-   "outputs": [
     {
      "data": {
       "text/html": [
@@ -183,13 +132,13 @@
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
        "      <th></th>\n",
-       "      <th>Column1</th>\n",
-       "      <th>Column2</th>\n",
-       "      <th>Column3</th>\n",
-       "      <th>Column4</th>\n",
-       "      <th>Column5</th>\n",
-       "      <th>Column6</th>\n",
-       "      <th>Column7</th>\n",
+       "      <th>column_0</th>\n",
+       "      <th>column_1</th>\n",
+       "      <th>column_2</th>\n",
+       "      <th>column_3</th>\n",
+       "      <th>column_4</th>\n",
+       "      <th>column_5</th>\n",
+       "      <th>column_6</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
@@ -198,7 +147,7 @@
        "      <td>main-captions</td>\n",
        "      <td>MSRvid</td>\n",
        "      <td>2012test</td>\n",
-       "      <td>1</td>\n",
+       "      <td>0001</td>\n",
        "      <td>5.00</td>\n",
        "      <td>A plane is taking off.</td>\n",
        "      <td>An air plane is taking off.</td>\n",
@@ -208,7 +157,7 @@
        "      <td>main-captions</td>\n",
        "      <td>MSRvid</td>\n",
        "      <td>2012test</td>\n",
-       "      <td>4</td>\n",
+       "      <td>0004</td>\n",
        "      <td>3.80</td>\n",
        "      <td>A man is playing a large flute.</td>\n",
        "      <td>A man is playing a flute.</td>\n",
@@ -218,7 +167,7 @@
        "      <td>main-captions</td>\n",
        "      <td>MSRvid</td>\n",
        "      <td>2012test</td>\n",
-       "      <td>5</td>\n",
+       "      <td>0005</td>\n",
        "      <td>3.80</td>\n",
        "      <td>A man is spreading shreded cheese on a pizza.</td>\n",
        "      <td>A man is spreading shredded cheese on an uncoo...</td>\n",
@@ -228,7 +177,7 @@
        "      <td>main-captions</td>\n",
        "      <td>MSRvid</td>\n",
        "      <td>2012test</td>\n",
-       "      <td>6</td>\n",
+       "      <td>0006</td>\n",
        "      <td>2.60</td>\n",
        "      <td>Three men are playing chess.</td>\n",
        "      <td>Two men are playing chess.</td>\n",
@@ -238,178 +187,59 @@
        "      <td>main-captions</td>\n",
        "      <td>MSRvid</td>\n",
        "      <td>2012test</td>\n",
-       "      <td>9</td>\n",
+       "      <td>0009</td>\n",
        "      <td>4.25</td>\n",
        "      <td>A man is playing the cello.</td>\n",
        "      <td>A man seated is playing the cello.</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>5</th>\n",
-       "      <td>main-captions</td>\n",
-       "      <td>MSRvid</td>\n",
-       "      <td>2012test</td>\n",
-       "      <td>11</td>\n",
-       "      <td>4.25</td>\n",
-       "      <td>Some men are fighting.</td>\n",
-       "      <td>Two men are fighting.</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>6</th>\n",
-       "      <td>main-captions</td>\n",
-       "      <td>MSRvid</td>\n",
-       "      <td>2012test</td>\n",
-       "      <td>12</td>\n",
-       "      <td>0.50</td>\n",
-       "      <td>A man is smoking.</td>\n",
-       "      <td>A man is skating.</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>7</th>\n",
-       "      <td>main-captions</td>\n",
-       "      <td>MSRvid</td>\n",
-       "      <td>2012test</td>\n",
-       "      <td>13</td>\n",
-       "      <td>1.60</td>\n",
-       "      <td>The man is playing the piano.</td>\n",
-       "      <td>The man is playing the guitar.</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>8</th>\n",
-       "      <td>main-captions</td>\n",
-       "      <td>MSRvid</td>\n",
-       "      <td>2012test</td>\n",
-       "      <td>14</td>\n",
-       "      <td>2.20</td>\n",
-       "      <td>A man is playing on a guitar and singing.</td>\n",
-       "      <td>A woman is playing an acoustic guitar and sing...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>9</th>\n",
-       "      <td>main-captions</td>\n",
-       "      <td>MSRvid</td>\n",
-       "      <td>2012test</td>\n",
-       "      <td>16</td>\n",
-       "      <td>5.00</td>\n",
-       "      <td>A person is throwing a cat on to the ceiling.</td>\n",
-       "      <td>A person throws a cat on the ceiling.</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "         Column1 Column2   Column3  Column4  Column5  \\\n",
-       "0  main-captions  MSRvid  2012test        1     5.00   \n",
-       "1  main-captions  MSRvid  2012test        4     3.80   \n",
-       "2  main-captions  MSRvid  2012test        5     3.80   \n",
-       "3  main-captions  MSRvid  2012test        6     2.60   \n",
-       "4  main-captions  MSRvid  2012test        9     4.25   \n",
-       "5  main-captions  MSRvid  2012test       11     4.25   \n",
-       "6  main-captions  MSRvid  2012test       12     0.50   \n",
-       "7  main-captions  MSRvid  2012test       13     1.60   \n",
-       "8  main-captions  MSRvid  2012test       14     2.20   \n",
-       "9  main-captions  MSRvid  2012test       16     5.00   \n",
+       "        column_0 column_1  column_2 column_3  column_4  \\\n",
+       "0  main-captions   MSRvid  2012test     0001      5.00   \n",
+       "1  main-captions   MSRvid  2012test     0004      3.80   \n",
+       "2  main-captions   MSRvid  2012test     0005      3.80   \n",
+       "3  main-captions   MSRvid  2012test     0006      2.60   \n",
+       "4  main-captions   MSRvid  2012test     0009      4.25   \n",
        "\n",
-       "                                         Column6  \\\n",
+       "                                        column_5  \\\n",
        "0                         A plane is taking off.   \n",
        "1                A man is playing a large flute.   \n",
        "2  A man is spreading shreded cheese on a pizza.   \n",
        "3                   Three men are playing chess.   \n",
        "4                    A man is playing the cello.   \n",
-       "5                         Some men are fighting.   \n",
-       "6                              A man is smoking.   \n",
-       "7                  The man is playing the piano.   \n",
-       "8      A man is playing on a guitar and singing.   \n",
-       "9  A person is throwing a cat on to the ceiling.   \n",
        "\n",
-       "                                             Column7  \n",
+       "                                            column_6  \n",
        "0                        An air plane is taking off.  \n",
        "1                          A man is playing a flute.  \n",
        "2  A man is spreading shredded cheese on an uncoo...  \n",
        "3                         Two men are playing chess.  \n",
-       "4                 A man seated is playing the cello.  \n",
-       "5                              Two men are fighting.  \n",
-       "6                                  A man is skating.  \n",
-       "7                     The man is playing the guitar.  \n",
-       "8  A woman is playing an acoustic guitar and sing...  \n",
-       "9              A person throws a cat on the ceiling.  "
+       "4                 A man seated is playing the cello.  "
       ]
      },
-     "execution_count": 6,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "dflow = dp.auto_read_file(path=os.path.join(datapath, \"sts-train.csv\"))\n",
-    "dflow.head()"
+    "df = stsbenchmark.load_pandas_df(RAW_DATA_PATH, file_split=\"train\")\n",
+    "df.head()"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The `auto_read_file` function from the AzureML Data Prep module actually returns a `Dataflow` object, which you can read more about [here](https://docs.microsoft.com/en-us/python/api/azureml-dataprep/azureml.dataprep.dataflow?view=azure-dataprep-py). We can easily transfer the data into a Pandas DataFrame (as before) in a single line using the `to_pandas_dataframe` function, or we can continue manipulating the data as a Dataflow object using the AzureML Data Prep API. For the remainder of this notebook we will be doing the latter."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### 03 Data Cleaning\n",
+    "### 02 Data Cleaning\n",
     "Now that we know about the general shape of the data, we can clean it so that it is ready for further preprocessing. The main operation we need for the STS Benchmark data is to drop all of columns except for the sentence pairs and scores."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "sentences = dflow.keep_columns([\"Column5\", \"Column6\", \"Column7\"]).rename_columns(\n",
-    "    {\"Column5\": \"score\", \"Column6\": \"sentence1\", \"Column7\": \"sentence2\"}\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### 04 One-Shot Dataframe Loading\n",
-    "You can also use our STSBenchmark utils to automatically download, extract, and persist the data. You can then load the sanitized data as a pandas DataFrame in one line. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "418kB [00:02, 191kB/s]                             \n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Data downloaded to ../../../data/raw/stsbenchmark\n",
-      "Writing clean dataframe to ../../../data/clean/stsbenchmark/sts-test.csv\n",
-      "Writing clean dataframe to ../../../data/clean/stsbenchmark/sts-dev.csv\n",
-      "Writing clean dataframe to ../../../data/clean/stsbenchmark/sts-train.csv\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Initializing this instance runs the downloader and extractor behind the scenes\n",
-    "sts_train = stsbenchmark.load_pandas_df(BASE_DATA_PATH, file_split=\"train\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -489,12 +319,13 @@
        "4                 A man seated is playing the cello.  "
       ]
      },
-     "execution_count": 9,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
+    "sts_train = stsbenchmark.clean_sts(df)\n",
     "sts_train.head()"
    ]
   },
@@ -502,13 +333,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 05 Make Lowercase\n",
-    "We start with simple standardization of the text by making all text lowercase."
+    "### 03 Make Lowercase\n",
+    "We do simple standardization of the text by making all text lowercase."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -588,7 +419,7 @@
        "4                 a man seated is playing the cello.  "
       ]
      },
-     "execution_count": 10,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -602,13 +433,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 06 Tokenize\n",
+    "### 04 Tokenize\n",
     "We tokenize the text using spaCy's non-destructive tokenizer."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -680,46 +511,6 @@
        "      <td>[a, man, is, playing, the, cello, .]</td>\n",
        "      <td>[a, man, seated, is, playing, the, cello, .]</td>\n",
        "    </tr>\n",
-       "    <tr>\n",
-       "      <th>5</th>\n",
-       "      <td>4.25</td>\n",
-       "      <td>some men are fighting.</td>\n",
-       "      <td>two men are fighting.</td>\n",
-       "      <td>[some, men, are, fighting, .]</td>\n",
-       "      <td>[two, men, are, fighting, .]</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>6</th>\n",
-       "      <td>0.50</td>\n",
-       "      <td>a man is smoking.</td>\n",
-       "      <td>a man is skating.</td>\n",
-       "      <td>[a, man, is, smoking, .]</td>\n",
-       "      <td>[a, man, is, skating, .]</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>7</th>\n",
-       "      <td>1.60</td>\n",
-       "      <td>the man is playing the piano.</td>\n",
-       "      <td>the man is playing the guitar.</td>\n",
-       "      <td>[the, man, is, playing, the, piano, .]</td>\n",
-       "      <td>[the, man, is, playing, the, guitar, .]</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>8</th>\n",
-       "      <td>2.20</td>\n",
-       "      <td>a man is playing on a guitar and singing.</td>\n",
-       "      <td>a woman is playing an acoustic guitar and sing...</td>\n",
-       "      <td>[a, man, is, playing, on, a, guitar, and, sing...</td>\n",
-       "      <td>[a, woman, is, playing, an, acoustic, guitar, ...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>9</th>\n",
-       "      <td>5.00</td>\n",
-       "      <td>a person is throwing a cat on to the ceiling.</td>\n",
-       "      <td>a person throws a cat on the ceiling.</td>\n",
-       "      <td>[a, person, is, throwing, a, cat, on, to, the,...</td>\n",
-       "      <td>[a, person, throws, a, cat, on, the, ceiling, .]</td>\n",
-       "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
@@ -731,11 +522,6 @@
        "2   3.80  a man is spreading shreded cheese on a pizza.   \n",
        "3   2.60                   three men are playing chess.   \n",
        "4   4.25                    a man is playing the cello.   \n",
-       "5   4.25                         some men are fighting.   \n",
-       "6   0.50                              a man is smoking.   \n",
-       "7   1.60                  the man is playing the piano.   \n",
-       "8   2.20      a man is playing on a guitar and singing.   \n",
-       "9   5.00  a person is throwing a cat on to the ceiling.   \n",
        "\n",
        "                                           sentence2  \\\n",
        "0                        an air plane is taking off.   \n",
@@ -743,11 +529,6 @@
        "2  a man is spreading shredded cheese on an uncoo...   \n",
        "3                         two men are playing chess.   \n",
        "4                 a man seated is playing the cello.   \n",
-       "5                              two men are fighting.   \n",
-       "6                                  a man is skating.   \n",
-       "7                     the man is playing the guitar.   \n",
-       "8  a woman is playing an acoustic guitar and sing...   \n",
-       "9              a person throws a cat on the ceiling.   \n",
        "\n",
        "                                    sentence1_tokens  \\\n",
        "0                     [a, plane, is, taking, off, .]   \n",
@@ -755,48 +536,36 @@
        "2  [a, man, is, spreading, shreded, cheese, on, a...   \n",
        "3               [three, men, are, playing, chess, .]   \n",
        "4               [a, man, is, playing, the, cello, .]   \n",
-       "5                      [some, men, are, fighting, .]   \n",
-       "6                           [a, man, is, smoking, .]   \n",
-       "7             [the, man, is, playing, the, piano, .]   \n",
-       "8  [a, man, is, playing, on, a, guitar, and, sing...   \n",
-       "9  [a, person, is, throwing, a, cat, on, to, the,...   \n",
        "\n",
        "                                    sentence2_tokens  \n",
        "0               [an, air, plane, is, taking, off, .]  \n",
        "1                 [a, man, is, playing, a, flute, .]  \n",
        "2  [a, man, is, spreading, shredded, cheese, on, ...  \n",
        "3                 [two, men, are, playing, chess, .]  \n",
-       "4       [a, man, seated, is, playing, the, cello, .]  \n",
-       "5                       [two, men, are, fighting, .]  \n",
-       "6                           [a, man, is, skating, .]  \n",
-       "7            [the, man, is, playing, the, guitar, .]  \n",
-       "8  [a, woman, is, playing, an, acoustic, guitar, ...  \n",
-       "9   [a, person, throws, a, cat, on, the, ceiling, .]  "
+       "4       [a, man, seated, is, playing, the, cello, .]  "
       ]
      },
-     "execution_count": 11,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "sts_train_tok = to_spacy_tokens(\n",
-    "    sts_train_low.head(10)\n",
-    ")  # operating on a small slice of the data as an example\n",
-    "sts_train_tok.head(10)"
+    "sts_train_tok = to_spacy_tokens(sts_train_low.head())\n",
+    "sts_train_tok.head()"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 07 Optional: Remove Stop Words\n",
+    "### 05 Optional: Remove Stop Words\n",
     "Removing stop words is another common preprocessing step for NLP tasks. We use the `rm_spacy_stopwords` utility function to do this on the dataframe. This function makes use of the spaCy language model's default set of stop words. If we need to add our own set of stop words (for example, if we are doing an NLP task for a very specific domain of content), we can do this in-line by simply providing the list as the `custom_stopwords` parameter of `rm_spacy_stopwords`."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -880,56 +649,6 @@
        "      <td>[man, playing, cello, .]</td>\n",
        "      <td>[man, seated, playing, cello, .]</td>\n",
        "    </tr>\n",
-       "    <tr>\n",
-       "      <th>5</th>\n",
-       "      <td>4.25</td>\n",
-       "      <td>some men are fighting.</td>\n",
-       "      <td>two men are fighting.</td>\n",
-       "      <td>[some, men, are, fighting, .]</td>\n",
-       "      <td>[two, men, are, fighting, .]</td>\n",
-       "      <td>[men, fighting, .]</td>\n",
-       "      <td>[men, fighting, .]</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>6</th>\n",
-       "      <td>0.50</td>\n",
-       "      <td>a man is smoking.</td>\n",
-       "      <td>a man is skating.</td>\n",
-       "      <td>[a, man, is, smoking, .]</td>\n",
-       "      <td>[a, man, is, skating, .]</td>\n",
-       "      <td>[man, smoking, .]</td>\n",
-       "      <td>[man, skating, .]</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>7</th>\n",
-       "      <td>1.60</td>\n",
-       "      <td>the man is playing the piano.</td>\n",
-       "      <td>the man is playing the guitar.</td>\n",
-       "      <td>[the, man, is, playing, the, piano, .]</td>\n",
-       "      <td>[the, man, is, playing, the, guitar, .]</td>\n",
-       "      <td>[man, playing, piano, .]</td>\n",
-       "      <td>[man, playing, guitar, .]</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>8</th>\n",
-       "      <td>2.20</td>\n",
-       "      <td>a man is playing on a guitar and singing.</td>\n",
-       "      <td>a woman is playing an acoustic guitar and sing...</td>\n",
-       "      <td>[a, man, is, playing, on, a, guitar, and, sing...</td>\n",
-       "      <td>[a, woman, is, playing, an, acoustic, guitar, ...</td>\n",
-       "      <td>[man, playing, guitar, singing, .]</td>\n",
-       "      <td>[woman, playing, acoustic, guitar, singing, .]</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>9</th>\n",
-       "      <td>5.00</td>\n",
-       "      <td>a person is throwing a cat on to the ceiling.</td>\n",
-       "      <td>a person throws a cat on the ceiling.</td>\n",
-       "      <td>[a, person, is, throwing, a, cat, on, to, the,...</td>\n",
-       "      <td>[a, person, throws, a, cat, on, the, ceiling, .]</td>\n",
-       "      <td>[person, throwing, cat, ceiling, .]</td>\n",
-       "      <td>[person, throws, cat, ceiling, .]</td>\n",
-       "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
@@ -941,11 +660,6 @@
        "2   3.80  a man is spreading shreded cheese on a pizza.   \n",
        "3   2.60                   three men are playing chess.   \n",
        "4   4.25                    a man is playing the cello.   \n",
-       "5   4.25                         some men are fighting.   \n",
-       "6   0.50                              a man is smoking.   \n",
-       "7   1.60                  the man is playing the piano.   \n",
-       "8   2.20      a man is playing on a guitar and singing.   \n",
-       "9   5.00  a person is throwing a cat on to the ceiling.   \n",
        "\n",
        "                                           sentence2  \\\n",
        "0                        an air plane is taking off.   \n",
@@ -953,11 +667,6 @@
        "2  a man is spreading shredded cheese on an uncoo...   \n",
        "3                         two men are playing chess.   \n",
        "4                 a man seated is playing the cello.   \n",
-       "5                              two men are fighting.   \n",
-       "6                                  a man is skating.   \n",
-       "7                     the man is playing the guitar.   \n",
-       "8  a woman is playing an acoustic guitar and sing...   \n",
-       "9              a person throws a cat on the ceiling.   \n",
        "\n",
        "                                    sentence1_tokens  \\\n",
        "0                     [a, plane, is, taking, off, .]   \n",
@@ -965,11 +674,6 @@
        "2  [a, man, is, spreading, shreded, cheese, on, a...   \n",
        "3               [three, men, are, playing, chess, .]   \n",
        "4               [a, man, is, playing, the, cello, .]   \n",
-       "5                      [some, men, are, fighting, .]   \n",
-       "6                           [a, man, is, smoking, .]   \n",
-       "7             [the, man, is, playing, the, piano, .]   \n",
-       "8  [a, man, is, playing, on, a, guitar, and, sing...   \n",
-       "9  [a, person, is, throwing, a, cat, on, to, the,...   \n",
        "\n",
        "                                    sentence2_tokens  \\\n",
        "0               [an, air, plane, is, taking, off, .]   \n",
@@ -977,11 +681,6 @@
        "2  [a, man, is, spreading, shredded, cheese, on, ...   \n",
        "3                 [two, men, are, playing, chess, .]   \n",
        "4       [a, man, seated, is, playing, the, cello, .]   \n",
-       "5                       [two, men, are, fighting, .]   \n",
-       "6                           [a, man, is, skating, .]   \n",
-       "7            [the, man, is, playing, the, guitar, .]   \n",
-       "8  [a, woman, is, playing, an, acoustic, guitar, ...   \n",
-       "9   [a, person, throws, a, cat, on, the, ceiling, .]   \n",
        "\n",
        "                 sentence1_tokens_rm_stopwords  \\\n",
        "0                           [plane, taking, .]   \n",
@@ -989,34 +688,22 @@
        "2  [man, spreading, shreded, cheese, pizza, .]   \n",
        "3                     [men, playing, chess, .]   \n",
        "4                     [man, playing, cello, .]   \n",
-       "5                           [men, fighting, .]   \n",
-       "6                            [man, smoking, .]   \n",
-       "7                     [man, playing, piano, .]   \n",
-       "8           [man, playing, guitar, singing, .]   \n",
-       "9          [person, throwing, cat, ceiling, .]   \n",
        "\n",
        "                       sentence2_tokens_rm_stopwords  \n",
        "0                            [air, plane, taking, .]  \n",
        "1                           [man, playing, flute, .]  \n",
        "2  [man, spreading, shredded, cheese, uncooked, p...  \n",
        "3                           [men, playing, chess, .]  \n",
-       "4                   [man, seated, playing, cello, .]  \n",
-       "5                                 [men, fighting, .]  \n",
-       "6                                  [man, skating, .]  \n",
-       "7                          [man, playing, guitar, .]  \n",
-       "8     [woman, playing, acoustic, guitar, singing, .]  \n",
-       "9                  [person, throws, cat, ceiling, .]  "
+       "4                   [man, seated, playing, cello, .]  "
       ]
      },
-     "execution_count": 12,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "rm_spacy_stopwords(\n",
-    "    sts_train_tok\n",
-    ")  # operating on a small slice of the data as an example"
+    "rm_spacy_stopwords(sts_train_tok).head()"
    ]
   }
  ],
@@ -1036,7 +723,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.5"
+   "version": "3.6.8"
   }
  },
  "nbformat": 4,

--- a/utils_nlp/dataset/stsbenchmark.py
+++ b/utils_nlp/dataset/stsbenchmark.py
@@ -71,7 +71,7 @@ def _extract_sts(tarpath, target_dirpath=".", tmode="r"):
 
 
 def _load_sts(src_file_path):
-    """Drop columns containing irrelevant metadata and save as new csv files in the target_dir
+    """Load datafile as dataframe
 
     Args:
         src_file_path (str): filepath to train/dev/test csv files.


### PR DESCRIPTION
### Description
1. Dataset had extra tabs in a few rows which was causing to skip rows with pandas when using read_csv() and auto_read_file() from azureml.dataprep package creates extra columns in the dataframe object.
2. Updated the python util and the notebook for it.
3. Readme link updated as well.

### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project, as detailed in our [contribution guidelines](../CONTRIBUTING.md).
- [ ] I have added tests.
- [] I have updated the documentation accordingly.



