### PR TITLE
Flake8 line length defaults (to 100?)

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -13,4 +13,4 @@
 # F821  undefined name 'get_ipython' --> from generated python files using nbconvert
 
 ignore = E203, E266, W503, F403, F405, E402, E731, F821
-max-line-length = 79
+max-line-length = 100


### PR DESCRIPTION
### Description
max line length in flake8: 79 -> 100


### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project, as detailed in our [contribution guidelines](../CONTRIBUTING.md).
- [ ] I have added tests.
- [ ] I have updated the documentation accordingly.



