### PR TITLE
Update min version for azureml

### DIFF
--- a/tools/generate_conda_file.py
+++ b/tools/generate_conda_file.py
@@ -55,7 +55,7 @@ CONDA_GPU = {
 
 PIP_BASE = {
     "azureml-sdk[notebooks,tensorboard]": (
-        "azureml-sdk[notebooks,tensorboard]==1.0.33"
+        "azureml-sdk[notebooks,tensorboard]>==1.0.33"
     ),
     "azureml-dataprep": "azureml-dataprep==1.1.4",
     "black": "black>=18.6b4",


### PR DESCRIPTION

### Description
Azureml notebooks have sdk version set to 1.0.45
Running conda create on azureml notebook causes ERROR: azureml-pipeline-core 1.0.43 has requirement azureml-core==1.0.43.*, but you'll have azureml-core 1.0.45 which is incompatible.

### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project, as detailed in our [contribution guidelines](../CONTRIBUTING.md).
- [ ] I have added tests.
- [ ] I have updated the documentation accordingly.



