### PR TITLE
add schedule

### DIFF
--- a/tests/ci/repo_metrics_pipeline.yml
+++ b/tests/ci/repo_metrics_pipeline.yml
@@ -1,4 +1,12 @@
-
+# More info on scheduling: https://docs.microsoft.com/en-us/azure/devops/pipelines/build/triggers?view=azure-devops&tabs=yaml#scheduled-triggers
+schedules:
+- cron: "56 22 * * *"
+  displayName: Daily track of metrics
+  branches:
+    include:
+    - master
+  always: true
+  
 jobs:
 - job: Repometrics
   pool:


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Fixes a bug in the repo metrics, this fix should make the metrics to be scheduled once a day at 10:56 p.m

### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/microsoft/nlp/issues/24

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project, as detailed in our [contribution guidelines](../CONTRIBUTING.md).
- [ ] I have added tests.
- [ ] I have updated the documentation accordingly.



