### PR TITLE
remove horovod from cpu environment

### DIFF
--- a/tools/generate_conda_file.py
+++ b/tools/generate_conda_file.py
@@ -84,11 +84,14 @@ PIP_BASE = {
 
 PIP_GPU = {}
 
-PIP_DARWIN = {"horovod": "horovod>=0.16.1"}
+PIP_DARWIN = {}
+PIP_DARWIN_GPU = {"horovod": "horovod>=0.16.1"}
 
-PIP_LINUX = {"horovod": "horovod>=0.16.1"}
+PIP_LINUX = {}
+PIP_LINUX_GPU = {"horovod": "horovod>=0.16.1"}
 
 PIP_WIN32 = {}
+PIP_WIN32_GPU = {}
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
@@ -119,21 +122,25 @@ if __name__ == "__main__":
     # update conda and pip packages based on flags provided
     conda_packages = CONDA_BASE
     pip_packages = PIP_BASE
-    if args.gpu:
-        conda_packages.update(CONDA_GPU)
-        pip_packages.update(PIP_GPU)
 
     # check for os platform support
     if platform == "darwin":
         pip_packages.update(PIP_DARWIN)
+        PIP_GPU.update(PIP_DARWIN_GPU)
     elif platform.startswith("linux"):
         pip_packages.update(PIP_LINUX)
+        PIP_GPU.update(PIP_LINUX_GPU)
     elif platform == "win32":
         pip_packages.update(PIP_WIN32)
+        PIP_GPU.update(PIP_WIN32_GPU)
     else:
         raise Exception(
             "Unsupported platform, must be Windows, Linux, or macOS"
         )
+
+    if args.gpu:
+        conda_packages.update(CONDA_GPU)
+        pip_packages.update(PIP_GPU)
 
     # write out yaml file
     conda_file = "{}.yaml".format(conda_env)


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Remove horovod from the cpu conda env creation process. It throws a lot of errors (especially on Mac) and is not used locally - only in AzureML or GPU-only workflows.

### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project, as detailed in our [contribution guidelines](../CONTRIBUTING.md).
- [ ] I have added tests.
- [ ] I have updated the documentation accordingly.



