### PR TITLE
Fix: Check semantic versioning in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,11 @@ from glob import glob
 from os.path import basename, dirname, join, splitext
 
 from setuptools import find_packages, setup
+from setuptools_scm import get_version
+
+# Determine semantic versioning automatically
+# from git commits
+__version__ = get_version()
 
 def read(*names, **kwargs):
     with io.open(
@@ -21,6 +26,7 @@ def read(*names, **kwargs):
 
 setup(
     name="utils_nlp",
+    version = __version__,
     license="MIT License",
     description="NLP Utility functions that are used for best practices in building state-of-the-art NLP methods and scenarios. Developed by Microsoft AI CAT",
     long_description="%s\n%s"
@@ -72,6 +78,6 @@ setup(
     install_requires=['setuptools_scm>=3.2.0',],
     dependency_links=[],
     extras_require={},
-    use_scm_version=True,
+    use_scm_version = {"root": ".", "relative_to": __file__},
     setup_requires=['setuptools_scm'],
 )

--- a/utils_nlp/__init__.py
+++ b/utils_nlp/__init__.py
@@ -1,5 +1,0 @@
-from setuptools_scm import get_version
-
-# Determine semantic versioning automatically
-# from git commits
-__version__ = get_version()


### PR DESCRIPTION
Author:    Emmanuel Awa <emmanuel.awa@microsoft.com>

### Description
<!--- Describe your changes in detail -->
1. Move the automatic getting of `utils_nlp` version from `utils_nlp/__init__.py` to the setup.py
1. Check semantic versioning in setup.py so scenario notebooks can find the right version of `utils_nlp` to use. 

<!--- Why is this change required? What problem does it solve? -->
To avoid the case where notebooks referencing `utils_nlp` could not figure out what version of the package to use. 

### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->
This closes #300 and #301 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project, as detailed in our [contribution guidelines](../CONTRIBUTING.md).
- [ ] I have added tests.
- [x] I have updated the documentation accordingly.



