### PR TITLE
Add pipelines to run existing cpu pytests on AzureML and update yaml pipelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,8 @@ The following is a list of related repositories that we like and think are usefu
 | --- | --- | --- | --- | --- | --- |
 | **Linux CPU** | master | [![Build Status](https://dev.azure.com/best-practices/nlp/_apis/build/status/cpu_integration_tests_linux?branchName=master)](https://dev.azure.com/best-practices/nlp/_build/latest?definitionId=50&branchName=master) | | staging | [![Build Status](https://dev.azure.com/best-practices/nlp/_apis/build/status/cpu_integration_tests_linux?branchName=staging)](https://dev.azure.com/best-practices/nlp/_build/latest?definitionId=50&branchName=staging) |
 | **Linux GPU** | master | [![Build Status](https://dev.azure.com/best-practices/nlp/_apis/build/status/gpu_integration_tests_linux?branchName=master)](https://dev.azure.com/best-practices/nlp/_build/latest?definitionId=51&branchName=master) | | staging | [![Build Status](https://dev.azure.com/best-practices/nlp/_apis/build/status/gpu_integration_tests_linux?branchName=staging)](https://dev.azure.com/best-practices/nlp/_build/latest?definitionId=51&branchName=staging) |
+
+## Build Status on AzureML
+| Build Type | Branch | Status |  | Branch | Status |
+| --- | --- | --- | --- | --- | --- |
+| **Linux CPU** | master | [![Build Status](https://dev.azure.com/best-practices/nlp/_apis/build/status/AzureML_nightly_cpu?branchName=master)](https://dev.azure.com/best-practices/nlp/_build/latest?definitionId=57&branchName=master)  | | staging | [![Build Status](https://dev.azure.com/best-practices/nlp/_apis/build/status/AzureML_nightly_cpu?branchName=staging)](https://dev.azure.com/best-practices/nlp/_build/latest?definitionId=57&branchName=staging) |

--- a/tests/README.md
+++ b/tests/README.md
@@ -10,6 +10,8 @@ For more information, see a [quick introduction to unit, smoke and integration t
 
 Tests are automatically run as part of a DevOps pipeline. The pipelines are defined in the `.yml` files in [tests/ci](./ci) with filenames that align with pipeline names.
 
+Tests are also run on AzureML in order to leverage the ability to turn on/off the VM, scale up and more.  Test badges for AzureML are in the README.md in the root folder.
+
 ## Test execution
 
 **Click on the following menus** to see more details on how to execute the unit, smoke and integration tests:

--- a/tests/ci/aml_cpu_unit_tests.yml
+++ b/tests/ci/aml_cpu_unit_tests.yml
@@ -1,0 +1,77 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+#
+variables:
+- group: AML-config
+- name  : 'test'
+  value : 'tests/ci/run_pytest.py'
+- name  : 'testfolder'
+  value : './tests/unit'
+- name  : 'testmarkers'
+  value : '"not notebooks and not gpu and not azureml"'
+- name  : 'junitxml'
+  value : 'reports/test-unit.xml'
+- name  : 'maxnodes'
+  value : 4
+- name  : 'reponame'
+  value : 'nlp'
+- name  : 'clustername'
+  #underscores not allowed, only letters, digits and - char
+  value : 'nlp-cpu'
+- name  : 'vmsize'
+  value : 'STANDARD_D3_V2'
+- name  : 'dockerproc'
+  value : 'cpu'
+- name  : 'expname'
+  value : 'cpu_unit_tests'
+
+trigger: none
+
+pr:
+- staging 
+- master
+
+jobs:
+- job: "Unit_test_cpu"
+  timeoutInMinutes: 120
+
+  pool:
+   vmImage: 'ubuntu-16.04'
+  
+  steps:
+  
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '3.6'
+      architecture: 'x64'
+    displayName: 'Use Python 3.6'
+  
+  - script: | 
+     az login --service-principal -u $(spidentity) -p $(spsecret) --tenant $(sptenant)
+    displayName: 'Login to Azure'
+  
+  - bash: |
+      echo "##vso[task.prependpath]/data/anaconda/bin"
+    displayName: Add Conda to PATH
+  
+  - script:
+       pip install paramiko==2.4.2 &&
+       pip install azureml-sdk &&
+       pip install azure-cli
+    displayName: 'install azureml-sdk'
+  
+  - script: 
+       python tools/generate_conda_file.py --name nlp 
+    displayName: ' generate_conda_file.py'
+  
+  - script: 
+      python tests/ci/submit_azureml_pytest.py --subid $(SubscriptionID) --testfolder $(testfolder) --testmarkers $(testmarkers) --clustername $(clustername) --expname $(expname) --dockerproc $(dockerproc) --junitxml $(junitxml) --reponame $(reponame) --branch $(Build.SourceBranchName)
+    displayName: 'submit_azureml_pytest'
+  
+  - task: PublishTestResults@2
+    displayName: 'Publish Test Results **/test-*.xml'
+    inputs:
+      testResultsFiles: '**/test-*.xml'
+      failTaskOnFailedTests: true
+      testRunTitle: 'AzureML cpu unit tests'
+    condition: succeededOrFailed()

--- a/tests/ci/aml_cpu_unit_tests.yml
+++ b/tests/ci/aml_cpu_unit_tests.yml
@@ -2,76 +2,72 @@
 # Licensed under the MIT License.
 #
 variables:
-- group: AML-config
-- name  : 'test'
-  value : 'tests/ci/run_pytest.py'
-- name  : 'testfolder'
-  value : './tests/unit'
-- name  : 'testmarkers'
-  value : '"not notebooks and not gpu and not azureml"'
-- name  : 'junitxml'
-  value : 'reports/test-unit.xml'
-- name  : 'maxnodes'
-  value : 4
-- name  : 'reponame'
-  value : 'nlp'
-- name  : 'clustername'
-  #underscores not allowed, only letters, digits and - char
-  value : 'nlp-cpu'
-- name  : 'vmsize'
-  value : 'STANDARD_D3_V2'
-- name  : 'dockerproc'
-  value : 'cpu'
-- name  : 'expname'
-  value : 'cpu_unit_tests'
+  - group: AML-config
+  - name: "test"
+    value: "tests/ci/run_pytest.py"
+  - name: "testfolder"
+    value: "./tests/unit"
+  - name: "testmarkers"
+    value: '"not notebooks and not gpu and not azureml"'
+  - name: "junitxml"
+    value: "reports/test-unit.xml"
+  - name: "maxnodes"
+    value: 4
+  - name: "reponame"
+    value: "nlp"
+  - name: "clustername"
+    #underscores not allowed, only letters, digits and - char
+    value: "nlp-cpu"
+  - name: "vmsize"
+    value: "STANDARD_D3_V2"
+  - name: "dockerproc"
+    value: "cpu"
+  - name: "expname"
+    value: "cpu_unit_tests"
 
 trigger: none
 
 pr:
-- staging 
-- master
+  - staging
+  - master
 
 jobs:
-- job: "Unit_test_cpu"
-  timeoutInMinutes: 120
+  - job: "Unit_test_cpu"
+    timeoutInMinutes: 120
 
-  pool:
-   vmImage: 'ubuntu-16.04'
-  
-  steps:
-  
-  - task: UsePythonVersion@0
-    inputs:
-      versionSpec: '3.6'
-      architecture: 'x64'
-    displayName: 'Use Python 3.6'
-  
-  - script: | 
-     az login --service-principal -u $(spidentity) -p $(spsecret) --tenant $(sptenant)
-    displayName: 'Login to Azure'
-  
-  - bash: |
-      echo "##vso[task.prependpath]/data/anaconda/bin"
-    displayName: Add Conda to PATH
-  
-  - script:
-       pip install paramiko==2.4.2 &&
-       pip install azureml-sdk &&
-       pip install azure-cli
-    displayName: 'install azureml-sdk'
-  
-  - script: 
-       python tools/generate_conda_file.py --name nlp 
-    displayName: ' generate_conda_file.py'
-  
-  - script: 
-      python tests/ci/submit_azureml_pytest.py --subid $(SubscriptionID) --testfolder $(testfolder) --testmarkers $(testmarkers) --clustername $(clustername) --expname $(expname) --dockerproc $(dockerproc) --junitxml $(junitxml) --reponame $(reponame) --branch $(Build.SourceBranchName)
-    displayName: 'submit_azureml_pytest'
-  
-  - task: PublishTestResults@2
-    displayName: 'Publish Test Results **/test-*.xml'
-    inputs:
-      testResultsFiles: '**/test-*.xml'
-      failTaskOnFailedTests: true
-      testRunTitle: 'AzureML cpu unit tests'
-    condition: succeededOrFailed()
+    pool:
+      vmImage: "ubuntu-16.04"
+
+    steps:
+      - task: UsePythonVersion@0
+        inputs:
+          versionSpec: "3.6"
+          architecture: "x64"
+        displayName: "Use Python 3.6"
+
+      - script: |
+          az login --service-principal -u $(spidentity) -p $(spsecret) --tenant $(sptenant)
+        displayName: "Login to Azure"
+
+      - bash: |
+          echo "##vso[task.prependpath]/data/anaconda/bin"
+        displayName: Add Conda to PATH
+
+      - script: pip install paramiko==2.4.2 &&
+          pip install azureml-sdk &&
+          pip install azure-cli
+        displayName: "install azureml-sdk"
+
+      - script: python tools/generate_conda_file.py --name nlp
+        displayName: " generate_conda_file.py"
+
+      - script: python tests/ci/submit_azureml_pytest.py --subid $(SubscriptionID) --testfolder $(testfolder) --testmarkers $(testmarkers) --clustername $(clustername) --expname $(expname) --dockerproc $(dockerproc) --junitxml $(junitxml) --reponame $(reponame) --branch $(Build.SourceBranchName)
+        displayName: "submit_azureml_pytest"
+
+      - task: PublishTestResults@2
+        displayName: "Publish Test Results **/test-*.xml"
+        inputs:
+          testResultsFiles: "**/test-*.xml"
+          failTaskOnFailedTests: true
+          testRunTitle: "AzureML cpu unit tests"
+        condition: succeededOrFailed()

--- a/tests/ci/aml_nightly_cpu.yml
+++ b/tests/ci/aml_nightly_cpu.yml
@@ -1,0 +1,151 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+#
+variables:
+- group: AML-config
+- name  : 'test'
+  value : 'tests/ci/run_pytest.py'
+- name  : 'maxnodes'
+  value : 4
+- name  : 'reponame'
+  value : 'nlp'
+
+schedules:
+- cron: "30 22 * * *"
+  displayName: Daily run
+  branches:
+    include:
+    - master
+    - staging
+  always: true
+
+trigger: none
+
+pr:
+- staging 
+- master
+
+jobs:
+- job: Smoke
+  displayName: 'Smoke cpu'
+  
+  pool:
+   vmImage: 'ubuntu-16.04'
+
+  variables:
+  - name  : 'testmarkers'
+    value : '"smoke and not gpu and not azureml"'
+  - name  : 'testfolder'
+    value : './tests/smoke'
+  - name  : 'junitxml'
+    value : 'reports/test-smoke.xml'  
+  - name  : 'clustername'
+    value : 'nlp-cpu'
+  - name  : 'vmsize'
+    value : 'STANDARD_D3_V2'
+  - name  : 'dockerproc'
+    value : 'cpu'
+  - name  : 'expname'
+    value : 'cpu_nightly_tests'
+
+  steps:
+
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '3.6'
+      architecture: 'x64'
+    displayName: 'Use Python 3.6'
+  
+  - script: | 
+     az login --service-principal -u $(spidentity) -p $(spsecret) --tenant $(sptenant)
+     
+    displayName: 'Login to Azure'
+  
+  - bash: |
+      echo "##vso[task.prependpath]/data/anaconda/bin"
+    displayName: Add Conda to PATH
+  
+  - script: 
+       pip install azureml-sdk &&
+       pip install azure-cli &&
+       pip install --upgrade azureml-sdk[cli]
+    displayName: 'pip install'
+    
+  - script: 
+       python tools/generate_conda_file.py --name nlp 
+    displayName: ' generate_conda_file.py'
+  
+  - script: 
+      python tests/ci/submit_azureml_pytest.py --subid $(SubscriptionID) --testfolder $(testfolder) --testmarkers $(testmarkers) --clustername $(clustername) --expname $(expname) --dockerproc $(dockerproc) --junitxml $(junitxml) --reponame $(reponame) --branch $(Build.SourceBranchName)
+    displayName: 'submit_azureml_pytest'
+  
+  - task: PublishTestResults@2
+    displayName: 'Publish Test Results **/test-*.xml'
+    inputs:
+      testResultsFiles: '**/test-*.xml'
+      failTaskOnFailedTests: true
+      testRunTitle: 'AzureML nightly cpu smoke tests'
+    condition: succeededOrFailed()
+  
+- job: Integration
+  timeoutInMinutes: 300
+  displayName: 'Integration cpu'
+  
+  pool:
+   vmImage: 'ubuntu-16.04'
+
+  variables:
+  - name  : 'testmarkers'
+    value : '"integration and not gpu and not azureml"'
+  - name  : 'testfolder'
+    value : './tests/integration'
+  - name  : 'junitxml'
+    value : 'reports/test-int.xml'
+  - name  : 'clustername'
+    value : 'nlp-cpu'
+  - name  : 'vmsize'
+    value : 'STANDARD_D3_V2'
+  - name  : 'dockerproc'
+    value : 'cpu'
+  - name  : 'expname'
+    value : 'cpu_unit_tests'
+
+  steps:
+
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '3.6'
+      architecture: 'x64'
+    displayName: 'Use Python 3.6'
+  
+  - script: | 
+     az login --service-principal -u $(spidentity) -p $(spsecret) --tenant $(sptenant)
+     
+    displayName: 'Login to Azure'
+  
+  - bash: |
+      echo "##vso[task.prependpath]/data/anaconda/bin"
+    displayName: Add Conda to PATH
+  
+  - script: 
+       pip install azureml-sdk &&
+       pip install azure-cli &&
+       pip install --upgrade azureml-sdk[cli]
+    displayName: 'pip install'
+    
+  - script: 
+       python tools/generate_conda_file.py --name nlp 
+    displayName: ' generate_conda_file.py'
+  
+  - script: 
+      python tests/ci/submit_azureml_pytest.py --subid $(SubscriptionID) --testfolder $(testfolder) --testmarkers $(testmarkers) --clustername $(clustername) --expname $(expname) --dockerproc $(dockerproc) --junitxml $(junitxml) --reponame $(reponame) --branch $(Build.SourceBranchName)
+    displayName: 'submit_azureml_pytest'
+  
+  - task: PublishTestResults@2
+    displayName: 'Publish Test Results **/test-*.xml'
+    inputs:
+      testResultsFiles: '**/test-*.xml'
+      failTaskOnFailedTests: true
+      testRunTitle: 'AzureML nightly cpu integration tests'
+    condition: succeededOrFailed()
+  

--- a/tests/ci/aml_nightly_cpu.yml
+++ b/tests/ci/aml_nightly_cpu.yml
@@ -2,150 +2,139 @@
 # Licensed under the MIT License.
 #
 variables:
-- group: AML-config
-- name  : 'test'
-  value : 'tests/ci/run_pytest.py'
-- name  : 'maxnodes'
-  value : 4
-- name  : 'reponame'
-  value : 'nlp'
+  - group: AML-config
+  - name: "test"
+    value: "tests/ci/run_pytest.py"
+  - name: "maxnodes"
+    value: 4
+  - name: "reponame"
+    value: "nlp"
 
 schedules:
-- cron: "30 22 * * *"
-  displayName: Daily run
-  branches:
-    include:
-    - master
-    - staging
-  always: true
+  - cron: "30 22 * * *"
+    displayName: Daily run
+    branches:
+      include:
+        - master
+        - staging
+    always: true
 
 trigger: none
 
-pr:
-- staging 
-- master
+pr: none
 
 jobs:
-- job: Smoke
-  displayName: 'Smoke cpu'
-  
-  pool:
-   vmImage: 'ubuntu-16.04'
+  - job: Smoke
+    displayName: "Smoke cpu"
 
-  variables:
-  - name  : 'testmarkers'
-    value : '"smoke and not gpu and not azureml"'
-  - name  : 'testfolder'
-    value : './tests/smoke'
-  - name  : 'junitxml'
-    value : 'reports/test-smoke.xml'  
-  - name  : 'clustername'
-    value : 'nlp-cpu'
-  - name  : 'vmsize'
-    value : 'STANDARD_D3_V2'
-  - name  : 'dockerproc'
-    value : 'cpu'
-  - name  : 'expname'
-    value : 'cpu_nightly_tests'
+    pool:
+      vmImage: "ubuntu-16.04"
 
-  steps:
+    variables:
+      - name: "testmarkers"
+        value: '"smoke and not gpu and not azureml"'
+      - name: "testfolder"
+        value: "./tests/smoke"
+      - name: "junitxml"
+        value: "reports/test-smoke.xml"
+      - name: "clustername"
+        value: "nlp-cpu"
+      - name: "vmsize"
+        value: "STANDARD_D3_V2"
+      - name: "dockerproc"
+        value: "cpu"
+      - name: "expname"
+        value: "cpu_nightly_tests"
 
-  - task: UsePythonVersion@0
-    inputs:
-      versionSpec: '3.6'
-      architecture: 'x64'
-    displayName: 'Use Python 3.6'
-  
-  - script: | 
-     az login --service-principal -u $(spidentity) -p $(spsecret) --tenant $(sptenant)
-     
-    displayName: 'Login to Azure'
-  
-  - bash: |
-      echo "##vso[task.prependpath]/data/anaconda/bin"
-    displayName: Add Conda to PATH
-  
-  - script: 
-       pip install azureml-sdk &&
-       pip install azure-cli &&
-       pip install --upgrade azureml-sdk[cli]
-    displayName: 'pip install'
-    
-  - script: 
-       python tools/generate_conda_file.py --name nlp 
-    displayName: ' generate_conda_file.py'
-  
-  - script: 
-      python tests/ci/submit_azureml_pytest.py --subid $(SubscriptionID) --testfolder $(testfolder) --testmarkers $(testmarkers) --clustername $(clustername) --expname $(expname) --dockerproc $(dockerproc) --junitxml $(junitxml) --reponame $(reponame) --branch $(Build.SourceBranchName)
-    displayName: 'submit_azureml_pytest'
-  
-  - task: PublishTestResults@2
-    displayName: 'Publish Test Results **/test-*.xml'
-    inputs:
-      testResultsFiles: '**/test-*.xml'
-      failTaskOnFailedTests: true
-      testRunTitle: 'AzureML nightly cpu smoke tests'
-    condition: succeededOrFailed()
-  
-- job: Integration
-  timeoutInMinutes: 300
-  displayName: 'Integration cpu'
-  
-  pool:
-   vmImage: 'ubuntu-16.04'
+    steps:
+      - task: UsePythonVersion@0
+        inputs:
+          versionSpec: "3.6"
+          architecture: "x64"
+        displayName: "Use Python 3.6"
 
-  variables:
-  - name  : 'testmarkers'
-    value : '"integration and not gpu and not azureml"'
-  - name  : 'testfolder'
-    value : './tests/integration'
-  - name  : 'junitxml'
-    value : 'reports/test-int.xml'
-  - name  : 'clustername'
-    value : 'nlp-cpu'
-  - name  : 'vmsize'
-    value : 'STANDARD_D3_V2'
-  - name  : 'dockerproc'
-    value : 'cpu'
-  - name  : 'expname'
-    value : 'cpu_unit_tests'
+      - script: |
+          az login --service-principal -u $(spidentity) -p $(spsecret) --tenant $(sptenant)
 
-  steps:
+        displayName: "Login to Azure"
 
-  - task: UsePythonVersion@0
-    inputs:
-      versionSpec: '3.6'
-      architecture: 'x64'
-    displayName: 'Use Python 3.6'
-  
-  - script: | 
-     az login --service-principal -u $(spidentity) -p $(spsecret) --tenant $(sptenant)
-     
-    displayName: 'Login to Azure'
-  
-  - bash: |
-      echo "##vso[task.prependpath]/data/anaconda/bin"
-    displayName: Add Conda to PATH
-  
-  - script: 
-       pip install azureml-sdk &&
-       pip install azure-cli &&
-       pip install --upgrade azureml-sdk[cli]
-    displayName: 'pip install'
-    
-  - script: 
-       python tools/generate_conda_file.py --name nlp 
-    displayName: ' generate_conda_file.py'
-  
-  - script: 
-      python tests/ci/submit_azureml_pytest.py --subid $(SubscriptionID) --testfolder $(testfolder) --testmarkers $(testmarkers) --clustername $(clustername) --expname $(expname) --dockerproc $(dockerproc) --junitxml $(junitxml) --reponame $(reponame) --branch $(Build.SourceBranchName)
-    displayName: 'submit_azureml_pytest'
-  
-  - task: PublishTestResults@2
-    displayName: 'Publish Test Results **/test-*.xml'
-    inputs:
-      testResultsFiles: '**/test-*.xml'
-      failTaskOnFailedTests: true
-      testRunTitle: 'AzureML nightly cpu integration tests'
-    condition: succeededOrFailed()
-  
+      - bash: |
+          echo "##vso[task.prependpath]/data/anaconda/bin"
+        displayName: Add Conda to PATH
+
+      - script: pip install azureml-sdk &&
+          pip install azure-cli &&
+          pip install --upgrade azureml-sdk[cli]
+        displayName: "pip install"
+
+      - script: python tools/generate_conda_file.py --name nlp
+        displayName: " generate_conda_file.py"
+
+      - script: python tests/ci/submit_azureml_pytest.py --subid $(SubscriptionID) --testfolder $(testfolder) --testmarkers $(testmarkers) --clustername $(clustername) --expname $(expname) --dockerproc $(dockerproc) --junitxml $(junitxml) --reponame $(reponame) --branch $(Build.SourceBranchName)
+        displayName: "submit_azureml_pytest"
+
+      - task: PublishTestResults@2
+        displayName: "Publish Test Results **/test-*.xml"
+        inputs:
+          testResultsFiles: "**/test-*.xml"
+          failTaskOnFailedTests: true
+          testRunTitle: "AzureML nightly cpu smoke tests"
+        condition: succeededOrFailed()
+
+  - job: Integration
+    timeoutInMinutes: 300
+    displayName: "Integration cpu"
+
+    pool:
+      vmImage: "ubuntu-16.04"
+
+    variables:
+      - name: "testmarkers"
+        value: '"integration and not gpu and not azureml"'
+      - name: "testfolder"
+        value: "./tests/integration"
+      - name: "junitxml"
+        value: "reports/test-int.xml"
+      - name: "clustername"
+        value: "nlp-cpu"
+      - name: "vmsize"
+        value: "STANDARD_D3_V2"
+      - name: "dockerproc"
+        value: "cpu"
+      - name: "expname"
+        value: "cpu_unit_tests"
+
+    steps:
+      - task: UsePythonVersion@0
+        inputs:
+          versionSpec: "3.6"
+          architecture: "x64"
+        displayName: "Use Python 3.6"
+
+      - script: |
+          az login --service-principal -u $(spidentity) -p $(spsecret) --tenant $(sptenant)
+
+        displayName: "Login to Azure"
+
+      - bash: |
+          echo "##vso[task.prependpath]/data/anaconda/bin"
+        displayName: Add Conda to PATH
+
+      - script: pip install azureml-sdk &&
+          pip install azure-cli &&
+          pip install --upgrade azureml-sdk[cli]
+        displayName: "pip install"
+
+      - script: python tools/generate_conda_file.py --name nlp
+        displayName: " generate_conda_file.py"
+
+      - script: python tests/ci/submit_azureml_pytest.py --subid $(SubscriptionID) --testfolder $(testfolder) --testmarkers $(testmarkers) --clustername $(clustername) --expname $(expname) --dockerproc $(dockerproc) --junitxml $(junitxml) --reponame $(reponame) --branch $(Build.SourceBranchName)
+        displayName: "submit_azureml_pytest"
+
+      - task: PublishTestResults@2
+        displayName: "Publish Test Results **/test-*.xml"
+        inputs:
+          testResultsFiles: "**/test-*.xml"
+          failTaskOnFailedTests: true
+          testRunTitle: "AzureML nightly cpu integration tests"
+        condition: succeededOrFailed()

--- a/tests/ci/cpu_integration_tests_linux.yml
+++ b/tests/ci/cpu_integration_tests_linux.yml
@@ -1,7 +1,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-
 # More info on scheduling: https://docs.microsoft.com/en-us/azure/devops/pipelines/build/triggers?view=azure-devops&tabs=yaml#scheduled-triggers
 # Implementing the scheduler from the dashboard
 # Uncomment in case it wants to be done from using the yml
@@ -13,7 +12,6 @@
 #    - master
 #  always: true
 
-
 # no PR builds
 pr: none
 
@@ -21,42 +19,42 @@ pr: none
 trigger: none
 
 jobs:
-- job: nightly
-  displayName : 'Nightly tests'
-  timeoutInMinutes: 180 # how long to run the job before automatically cancelling
-  pool:
-    name: nlpagentpool
+  - job: nightly
+    displayName: "Nightly tests"
+    timeoutInMinutes: 180 # how long to run the job before automatically cancelling
+    pool:
+      name: nlpagentpool
 
-  steps:
-  - bash: |
-      echo "##vso[task.prependpath]/data/anaconda/bin"
-      conda env list
-    displayName: 'Add Conda to PATH'
+    steps:
+      - bash: |
+          echo "##vso[task.prependpath]/data/anaconda/bin"
+          conda env list
+        displayName: "Add Conda to PATH"
 
-  # Conda creation can take around 10min
-  - bash: |
-      python tools/generate_conda_file.py 
-      conda env create -n integration_cpu -f nlp_cpu.yaml
-    displayName: 'Creating Conda Environment with dependencies'
+      # Conda creation can take around 10min
+      - bash: |
+          python tools/generate_conda_file.py 
+          conda env create -n integration_cpu -f nlp_cpu.yaml
+        displayName: "Creating Conda Environment with dependencies"
 
-  - bash: |
-      source activate integration_cpu
-      pytest --durations=0 tests/smoke -m "smoke and not gpu and not azureml" --junitxml=junit/test-smoke-test.xml
-    displayName: 'Run smoke tests'
+      - bash: |
+          source activate integration_cpu
+          pytest --durations=0 tests/smoke -m "smoke and not gpu and not azureml" --junitxml=junit/test-smoke-test.xml
+        displayName: "Run smoke tests"
 
-  - bash: |
-      source activate integration_cpu
-      pytest --durations=0 tests/integration -m "integration and not gpu and not azureml" --junitxml=junit/test-integration-test.xml
-    displayName: 'Run integration tests'
+      - bash: |
+          source activate integration_cpu
+          pytest --durations=0 tests/integration -m "integration and not gpu and not azureml" --junitxml=junit/test-integration-test.xml
+        displayName: "Run integration tests"
 
-  - bash: |
-      echo Remove Conda Environment
-      conda remove -n integration_cpu --all -q --force -y
-      echo Done Cleanup
-    displayName: 'Cleanup Task'
-    condition: always()
+      - bash: |
+          echo Remove Conda Environment
+          conda remove -n integration_cpu --all -q --force -y
+          echo Done Cleanup
+        displayName: "Cleanup Task"
+        condition: always()
 
-  - task: PublishTestResults@2
-    inputs:
-      testResultsFiles: '**/test-*-test.xml'
-      testRunTitle: 'Test results for PyTest'
+      - task: PublishTestResults@2
+        inputs:
+          testResultsFiles: "**/test-*-test.xml"
+          testRunTitle: "Test results for PyTest"

--- a/tests/ci/cpu_unit_tests_linux.yml
+++ b/tests/ci/cpu_unit_tests_linux.yml
@@ -3,62 +3,57 @@
 
 # Pull request against these branches will trigger this build
 pr:
-- master
-- staging
+  - master
+  - staging
 
 #Any commit to this branch will trigger the build.
-trigger:
-- staging
-- master
-
+trigger: none
 
 jobs:
-- job: cpu_unit_tests_linux
-  timeoutInMinutes: 10 # how long to run the job before automatically cancelling
-  pool:
-    # vmImage: 'ubuntu-16.04' # hosted machine 
-    name: nlpagentpool
+  - job: cpu_unit_tests_linux
+    timeoutInMinutes: 10 # how long to run the job before automatically cancelling
+    pool:
+      # vmImage: 'ubuntu-16.04' # hosted machine
+      name: nlpagentpool
 
-  steps:
+    steps:
+      # Uncomment if hosted machine
+      #  - task: UsePythonVersion@0
+      #    inputs:
+      #      versionSpec: '3.6.8'
+      #      architecture: 'x64'
+      #      addToPath: true
+      #    displayName: 'Use Python 3.6.8'
 
-# Uncomment if hosted machine
-#  - task: UsePythonVersion@0
-#    inputs:
-#      versionSpec: '3.6.8'
-#      architecture: 'x64'
-#      addToPath: true
-#    displayName: 'Use Python 3.6.8'
-  
-  - bash: |
-      echo "##vso[task.prependpath]/data/anaconda/bin"
-      conda env list
-    displayName: Add Conda to PATH
+      - bash: |
+          echo "##vso[task.prependpath]/data/anaconda/bin"
+          conda env list
+        displayName: Add Conda to PATH
 
-# Uncomment if needed
-# Conda creation can take around 10min
-#  - bash: |
-#      python tools/generate_conda_file.py
-#      conda env create -n nlp_cpu -f nlp_cpu.yaml
-#    displayName: 'Creating Conda Environment with dependencies'
+      # Uncomment if needed
+      # Conda creation can take around 10min
+      #  - bash: |
+      #      python tools/generate_conda_file.py
+      #      conda env create -n nlp_cpu -f nlp_cpu.yaml
+      #    displayName: 'Creating Conda Environment with dependencies'
 
-  - bash: |
-      source activate nlp_cpu
-      pytest --durations=0 tests/unit -m "not notebooks and not gpu and not azureml" --junitxml=junit/test-unitttest.xml
-    displayName: 'Run Unit tests'
+      - bash: |
+          source activate nlp_cpu
+          pytest --durations=0 tests/unit -m "not notebooks and not gpu and not azureml" --junitxml=junit/test-unitttest.xml
+        displayName: "Run Unit tests"
 
-# Uncomment if needed
-#  - bash: |
-#      echo Remove Conda Environment
-#      conda remove -n nlp_cpu --all -q --force -y
-#      echo Done Cleanup
-#    displayName: 'Cleanup Task'
-#    condition: always()
+      # Uncomment if needed
+      #  - bash: |
+      #      echo Remove Conda Environment
+      #      conda remove -n nlp_cpu --all -q --force -y
+      #      echo Done Cleanup
+      #    displayName: 'Cleanup Task'
+      #    condition: always()
 
-  - task: PublishTestResults@2
-    inputs:
-      testResultsFiles: '**/test-unitttest.xml'
-      testRunTitle: 'Test results for PyTest'
-
+      - task: PublishTestResults@2
+        inputs:
+          testResultsFiles: "**/test-unitttest.xml"
+          testRunTitle: "Test results for PyTest"
 # Executed only once in notebook_cpu_unit_tests_linux
 #  - task: ComponentGovernanceComponentDetection@0
 #    inputs:

--- a/tests/ci/gpu_unit_tests_linux.yml
+++ b/tests/ci/gpu_unit_tests_linux.yml
@@ -3,51 +3,48 @@
 
 # Pull request against these branches will trigger this build
 pr:
-- master
-- staging
+  - master
+  - staging
 
 #Any commit to this branch will trigger the build.
-trigger:
-- staging
-- master
+trigger: none
 
 jobs:
-- job: gpu_unit_tests_linux
-  timeoutInMinutes: 10 # how long to run the job before automatically cancelling
-  pool:
-    name: nlpagentpool
+  - job: gpu_unit_tests_linux
+    timeoutInMinutes: 10 # how long to run the job before automatically cancelling
+    pool:
+      name: nlpagentpool
 
-  steps:
-  - bash: |
-      echo "##vso[task.prependpath]/data/anaconda/bin"
-      conda env list
-    displayName: Add Conda to PATH
+    steps:
+      - bash: |
+          echo "##vso[task.prependpath]/data/anaconda/bin"
+          conda env list
+        displayName: Add Conda to PATH
 
-# Uncomment if needed
-# Conda creation can take around 10min
-#  - bash: |
-#      python tools/generate_conda_file.py --gpu
-#      conda env create -n nlp_gpu -f nlp_gpu.yaml
-#    displayName: 'Creating Conda Environment with dependencies'
+      # Uncomment if needed
+      # Conda creation can take around 10min
+      #  - bash: |
+      #      python tools/generate_conda_file.py --gpu
+      #      conda env create -n nlp_gpu -f nlp_gpu.yaml
+      #    displayName: 'Creating Conda Environment with dependencies'
 
-  - bash: |
-      source activate nlp_gpu
-      pytest --durations=0 tests/unit -m "not notebooks and gpu and not azureml" --junitxml=junit/test-unitttest.xml
-    displayName: 'Run Unit tests'
+      - bash: |
+          source activate nlp_gpu
+          pytest --durations=0 tests/unit -m "not notebooks and gpu and not azureml" --junitxml=junit/test-unitttest.xml
+        displayName: "Run Unit tests"
 
-# Uncomment if needed
-#  - bash: |
-#      echo Remove Conda Environment
-#      conda remove -n nlp_gpu --all -q --force -y
-#      echo Done Cleanup
-#    displayName: 'Cleanup Task'
-#    condition: always()
+      # Uncomment if needed
+      #  - bash: |
+      #      echo Remove Conda Environment
+      #      conda remove -n nlp_gpu --all -q --force -y
+      #      echo Done Cleanup
+      #    displayName: 'Cleanup Task'
+      #    condition: always()
 
-  - task: PublishTestResults@2
-    inputs:
-      testResultsFiles: '**/test-unitttest.xml'
-      testRunTitle: 'Test results for PyTest'
-
+      - task: PublishTestResults@2
+        inputs:
+          testResultsFiles: "**/test-unitttest.xml"
+          testRunTitle: "Test results for PyTest"
 # Executed only once in notebook_cpu_unit_tests_linux
 #  - task: ComponentGovernanceComponentDetection@0
 #    inputs:

--- a/tests/ci/notebooks_cpu_unit_tests_linux.yml
+++ b/tests/ci/notebooks_cpu_unit_tests_linux.yml
@@ -3,53 +3,51 @@
 
 # Pull request against these branches will trigger this build
 pr:
-- master
-- staging
+  - master
+  - staging
 
 #Any commit to this branch will trigger the build.
-trigger:
-- staging
-- master
+trigger: none
 
 jobs:
-- job: notebooks_cpu_unit_tests_linux
-  timeoutInMinutes: 10 # how long to run the job before automatically cancelling
-  pool:
-    name: nlpagentpool
+  - job: notebooks_cpu_unit_tests_linux
+    timeoutInMinutes: 10 # how long to run the job before automatically cancelling
+    pool:
+      name: nlpagentpool
 
-  steps:
-  - bash: |
-      echo "##vso[task.prependpath]/data/anaconda/bin"
-      conda env list
-    displayName: Add Conda to PATH
+    steps:
+      - bash: |
+          echo "##vso[task.prependpath]/data/anaconda/bin"
+          conda env list
+        displayName: Add Conda to PATH
 
-# Uncomment if needed
-# Conda creation can take around 10min
-#  - bash: |
-#      python tools/generate_conda_file.py
-#      conda env create -n nlp_cpu -f nlp_cpu.yaml
-#    displayName: 'Creating Conda Environment with dependencies'
+      # Uncomment if needed
+      # Conda creation can take around 10min
+      #  - bash: |
+      #      python tools/generate_conda_file.py
+      #      conda env create -n nlp_cpu -f nlp_cpu.yaml
+      #    displayName: 'Creating Conda Environment with dependencies'
 
-  - bash: |
-      source activate nlp_cpu
-      pytest --durations=0 tests/unit -m "notebooks and not gpu and not azureml" --junitxml=junit/test-unitttest.xml
-    displayName: 'Run Unit tests'
+      - bash: |
+          source activate nlp_cpu
+          pytest --durations=0 tests/unit -m "notebooks and not gpu and not azureml" --junitxml=junit/test-unitttest.xml
+        displayName: "Run Unit tests"
 
-# Uncomment if needed
-#  - bash: |
-#      echo Remove Conda Environment
-#      conda remove -n nlp_cpu --all -q --force -y
-#      echo Done Cleanup
-#    displayName: 'Cleanup Task'
-#    condition: always()
+      # Uncomment if needed
+      #  - bash: |
+      #      echo Remove Conda Environment
+      #      conda remove -n nlp_cpu --all -q --force -y
+      #      echo Done Cleanup
+      #    displayName: 'Cleanup Task'
+      #    condition: always()
 
-  - task: PublishTestResults@2
-    inputs:
-      testResultsFiles: '**/test-unitttest.xml'
-      testRunTitle: 'Test results for PyTest'
+      - task: PublishTestResults@2
+        inputs:
+          testResultsFiles: "**/test-unitttest.xml"
+          testRunTitle: "Test results for PyTest"
 
-  - task: ComponentGovernanceComponentDetection@0
-    inputs:
-      scanType: 'Register'
-      verbosity: 'Verbose'
-      alertWarningLevel: 'High'
+      - task: ComponentGovernanceComponentDetection@0
+        inputs:
+          scanType: "Register"
+          verbosity: "Verbose"
+          alertWarningLevel: "High"

--- a/tests/ci/notebooks_gpu_unit_tests_linux.yml
+++ b/tests/ci/notebooks_gpu_unit_tests_linux.yml
@@ -7,9 +7,7 @@ pr:
 - staging
 
 #Any commit to this branch will trigger the build.
-trigger:
-- staging
-- master
+trigger: none
 
 jobs:
 - job: notebooks_gpu_unit_tests_linux

--- a/tests/ci/run_pytest.py
+++ b/tests/ci/run_pytest.py
@@ -1,0 +1,87 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+"""
+run_pytest.py is the script submitted to Azure ML that runs pytest.
+pytest runs all tests in the specified test folder unless parameters
+are set otherwise.
+"""
+
+import argparse
+import subprocess
+import logging
+import os
+import sys
+from azureml.core import Run
+
+
+def create_arg_parser():
+    parser = argparse.ArgumentParser(description="Process inputs")
+    # test folder
+    parser.add_argument(
+        "--testfolder",
+        "-f",
+        action="store",
+        default="./tests/unit",
+        help="Folder where tests are located",
+    )
+    parser.add_argument("--num", action="store", default="99", help="test num")
+    # test markers
+    parser.add_argument(
+        "--testmarkers",
+        "-m",
+        action="store",
+        default="not notebooks and not spark and not gpu",
+        help="Specify test markers for test selection",
+    )
+    # test results file
+    parser.add_argument(
+        "--xmlname",
+        "-j",
+        action="store",
+        default="reports/test-unit.xml",
+        help="Test results",
+    )
+    args = parser.parse_args()
+
+    return args
+
+
+if __name__ == "__main__":
+    logger = logging.getLogger("submit_azureml_pytest.py")
+    args = create_arg_parser()
+
+    logging.basicConfig(stream=sys.stdout, level=logging.INFO)
+
+    logger.debug("junit_xml {}".format(args.xmlname))
+
+    # Run.get_context() is needed to save context as pytest causes corruption
+    # of env vars
+    run = Run.get_context()
+    """
+    This is an example of a working subprocess.run for a unit test run:
+    subprocess.run(["pytest", "tests/unit",
+                    "-m", "not notebooks and not spark and not gpu",
+                    "--junitxml=reports/test-unit.xml"])
+    """
+    logger.debug("args.junitxml {}".format(args.xmlname))
+    logger.debug("junit= --junitxml={}".format(args.xmlname))
+    pytest_cmd = [
+        "pytest",
+        args.testfolder,
+        "-m",
+        args.testmarkers,
+        "--junitxml={}".format(args.xmlname),
+    ]
+    logger.info("pytest run:{}".format(" ".join(pytest_cmd)))
+    subprocess.run(pytest_cmd)
+
+    #
+    # Leveraged code from this  notebook:
+    # https://msdata.visualstudio.com/Vienna/_search?action=contents&text=upload_folder&type=code&lp=code-Project&filters=ProjectFilters%7BVienna%7DRepositoryFilters%7BAzureMlCli%7D&pageSize=25&sortOptions=%5B%7B%22field%22%3A%22relevance%22%2C%22sortOrder%22%3A%22desc%22%7D%5D&result=DefaultCollection%2FVienna%2FAzureMlCli%2FGBmaster%2F%2Fsrc%2Fazureml-core%2Fazureml%2Fcore%2Frun.py
+    logger.debug("os.listdir files {}".format(os.listdir(".")))
+
+    #  files for AzureML
+    name_of_upload = "reports"
+    path_on_disk = "./reports"
+    run.upload_folder(name_of_upload, path_on_disk)

--- a/tests/ci/run_pytest.py
+++ b/tests/ci/run_pytest.py
@@ -36,11 +36,7 @@ def create_arg_parser():
     )
     # test results file
     parser.add_argument(
-        "--xmlname",
-        "-j",
-        action="store",
-        default="reports/test-unit.xml",
-        help="Test results",
+        "--xmlname", "-j", action="store", default="reports/test-unit.xml", help="Test results"
     )
     args = parser.parse_args()
 

--- a/tests/ci/submit_azureml_pytest.py
+++ b/tests/ci/submit_azureml_pytest.py
@@ -1,0 +1,440 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+"""
+This python script sets up an environment on AzureML and submits a
+script to it to run pytest.  It is usually intended to be used as
+part of a DevOps pipeline which runs testing on a github repo but
+can also be used from command line.
+
+Many parameters are set to default values and some are expected to be passed
+in from either the DevOps pipeline or command line.
+If calling from command line, there are some parameters you must pass in for
+your job to run.
+
+
+Args:
+    Required:
+    --clustername (str): the Azure cluster for this run. It can already exist
+                         or it will be created.
+    --subid       (str): the Azure subscription id
+
+    Optional but suggested, this info will be stored on Azure as
+    text information as part of the experiment:
+    --pr          (str): the Github PR number
+    --reponame    (str): the Github repository name
+    --branch      (str): the branch being run
+                    It is also possible to put any text string in these.
+Example:
+    Usually, this script is run by a DevOps pipeline. It can also be
+    run from cmd line.
+    >>> python tests/ci/refac.py --clustername 'cluster-d3-v2'
+                                 --subid '12345678-9012-3456-abcd-123456789012'
+                                 --pr '666'
+                                 --reponame 'nlp'
+                                 --branch 'staging'
+"""
+import argparse
+import logging
+
+from azureml.core.authentication import AzureCliAuthentication
+from azureml.core import Workspace
+from azureml.core import Experiment
+from azureml.core.runconfig import RunConfiguration
+from azureml.core.conda_dependencies import CondaDependencies
+from azureml.core.script_run_config import ScriptRunConfig
+from azureml.core.compute import ComputeTarget, AmlCompute
+from azureml.core.compute_target import ComputeTargetException
+from azureml.core.workspace import WorkspaceException
+
+
+def setup_workspace(
+    workspace_name, subscription_id, resource_group, cli_auth, location
+):
+    """
+    This sets up an Azure Workspace.
+    An existing Azure Workspace is used or a new one is created if needed for
+    the pytest run.
+
+    Args:
+        workspace_name  (str): Centralized location on Azure to work
+                               with all the artifacts used by AzureML
+                               service
+        subscription_id (str): the Azure subscription id
+        resource_group  (str): Azure Resource Groups are logical collections of
+                         assets associated with a project. Resource groups
+                         make it easy to track or delete all resources
+                         associated with a project by tracking or deleting
+                         the Resource group.
+        cli_auth         Azure authentication
+        location        (str): workspace reference
+
+    Returns:
+        ws: workspace reference
+    """
+    logger.debug("setup: workspace_name is {}".format(workspace_name))
+    logger.debug("setup: resource_group is {}".format(resource_group))
+    logger.debug("setup: subid is {}".format(subscription_id))
+    logger.debug("setup: location is {}".format(location))
+
+    try:
+        # use existing workspace if there is one
+        ws = Workspace.get(
+            name=workspace_name,
+            subscription_id=subscription_id,
+            resource_group=resource_group,
+            auth=cli_auth,
+        )
+    except WorkspaceException:
+        # this call might take a minute or two.
+        logger.debug("Creating new workspace")
+        ws = Workspace.create(
+            name=workspace_name,
+            subscription_id=subscription_id,
+            resource_group=resource_group,
+            # create_resource_group=True,
+            location=location,
+            auth=cli_auth,
+        )
+    return ws
+
+
+def setup_persistent_compute_target(
+    workspace, cluster_name, vm_size, max_nodes
+):
+    """
+    Set up a persistent compute target on AzureML.
+    A persistent compute target runs noticeably faster than a
+    regular compute target for subsequent runs.  The benefit
+    is that AzureML manages turning the compute on/off as needed for
+    each job so the user does not need to do this.
+
+    Args:
+        workspace    (str): Centralized location on Azure to work with
+                         all the
+                                artifacts used by AzureML service
+        cluster_name (str): the Azure cluster for this run. It can
+                            already exist or it will be created.
+        vm_size      (str): Azure VM size, like STANDARD_D3_V2
+        max_nodes    (int): Number of VMs, max_nodes=4 will
+                            autoscale up to 4 VMs
+    Returns:
+        cpu_cluster : cluster reference
+    """
+    # setting vmsize and num nodes creates a persistent AzureML
+    # compute resource
+
+    logger.debug("setup: cluster_name {}".format(cluster_name))
+    # https://docs.microsoft.com/en-us/azure/machine-learning/service/how-to-set-up-training-targets
+
+    try:
+        cpu_cluster = ComputeTarget(workspace=workspace, name=cluster_name)
+        logger.debug("setup: Found existing cluster, use it.")
+    except ComputeTargetException:
+        logger.debug("setup: create cluster")
+        compute_config = AmlCompute.provisioning_configuration(
+            vm_size=vm_size, max_nodes=max_nodes
+        )
+        cpu_cluster = ComputeTarget.create(
+            workspace, cluster_name, compute_config
+        )
+    cpu_cluster.wait_for_completion(show_output=True)
+    return cpu_cluster
+
+
+def create_run_config(cpu_cluster, docker_proc_type, conda_env_file):
+    """
+    AzureML requires the run environment to be setup prior to submission.
+    This configures a docker persistent compute.  Even though
+    it is called Persistent compute, AzureML handles startup/shutdown
+    of the compute environment.
+
+    Args:
+        cpu_cluster      (str) : Names the cluster for the test
+                                 In the case of unit tests, any of
+                                 the following:
+                                 - Reco_cpu_test
+                                 - Reco_gpu_test
+        docker_proc_type (str) : processor type, cpu or gpu
+        conda_env_file   (str) : filename which contains info to
+                                 set up conda env
+    Return:
+          run_amlcompute : AzureML run config
+    """
+
+    # runconfig with max_run_duration_seconds did not work, check why:
+    # run_amlcompute = RunConfiguration(max_run_duration_seconds=60*30)
+    run_amlcompute = RunConfiguration()
+    run_amlcompute.target = cpu_cluster
+    run_amlcompute.environment.docker.enabled = True
+    run_amlcompute.environment.docker.base_image = docker_proc_type
+
+    # Use conda_dependencies.yml to create a conda environment in
+    # the Docker image for execution
+    # False means the user will provide a conda file for setup
+    # True means the user will manually configure the environment
+    run_amlcompute.environment.python.user_managed_dependencies = False
+    run_amlcompute.environment.python.conda_dependencies = CondaDependencies(
+        conda_dependencies_file_path=conda_env_file
+    )
+    return run_amlcompute
+
+
+def create_experiment(workspace, experiment_name):
+    """
+    AzureML requires an experiment as a container of trials.
+    This will either create a new experiment or use an
+    existing one.
+
+    Args:
+        workspace (str) : name of AzureML workspace
+        experiment_name (str) : AzureML experiment name
+    Return:
+        exp - AzureML experiment
+    """
+
+    logger.debug("create: experiment_name {}".format(experiment_name))
+    exp = Experiment(workspace=workspace, name=experiment_name)
+    return exp
+
+
+def submit_experiment_to_azureml(
+    test, test_folder, test_markers, junitxml, run_config, experiment
+):
+
+    """
+    Submitting the experiment to AzureML actually runs the script.
+
+    Args:
+        test         (str) - pytest script, folder/test
+                             such as ./tests/ci/run_pytest.py
+        test_folder  (str) - folder where tests to run are stored,
+                             like ./tests/unit
+        test_markers (str) - test markers used by pytest
+                             "not notebooks and not spark and not gpu"
+        junitxml     (str) - file of output summary of tests run
+                             note "--junitxml" is required as part
+                             of the string
+                             Example: "--junitxml reports/test-unit.xml"
+        run_config - environment configuration
+        experiment - instance of an Experiment, a collection of
+                     trials where each trial is a run.
+    Return:
+          run : AzureML run or trial
+    """
+
+    logger.debug("submit: testfolder {}".format(test_folder))
+    logger.debug("junitxml: {}".format(junitxml))
+    project_folder = "."
+
+    script_run_config = ScriptRunConfig(
+        source_directory=project_folder,
+        script=test,
+        run_config=run_config,
+        arguments=[
+            "--testfolder",
+            test_folder,
+            "--testmarkers",
+            test_markers,
+            "--xmlname",
+            junitxml,
+        ],
+    )
+    run = experiment.submit(script_run_config)
+    # waits only for configuration to complete
+    run.wait_for_completion(show_output=True, wait_post_processing=True)
+
+    # test logs can also be found on azure
+    # go to azure portal to see log in azure ws and look for experiment name
+    # and look for individual run
+    logger.debug("files {}".format(run.get_file_names))
+
+    return run
+
+
+def create_arg_parser():
+    """
+    Many of the argument defaults are used as arg_parser makes it easy to
+    use defaults. The user has many options they can select.
+    """
+
+    parser = argparse.ArgumentParser(description="Process some inputs")
+    # script to run pytest
+    parser.add_argument(
+        "--test",
+        action="store",
+        default="./tests/ci/run_pytest.py",
+        help="location of script to run pytest",
+    )
+    # test folder
+    parser.add_argument(
+        "--testfolder",
+        action="store",
+        default="./tests/unit",
+        help="folder where tests are stored",
+    )
+    # pytest test markers
+    parser.add_argument(
+        "--testmarkers",
+        action="store",
+        default="not notebooks and not spark and not gpu",
+        help="pytest markers indicate tests to run",
+    )
+    # test summary file
+    parser.add_argument(
+        "--junitxml",
+        action="store",
+        default="reports/test-unit.xml",
+        help="file for returned test results",
+    )
+    # max num nodes in Azure cluster
+    parser.add_argument(
+        "--maxnodes",
+        action="store",
+        default=4,
+        help="specify the maximum number of nodes for the run",
+    )
+    # Azure resource group
+    parser.add_argument(
+        "--rg",
+        action="store",
+        default="nlpbp_project_resources",
+        help="Azure Resource Group",
+    )
+    # AzureML workspace Name
+    parser.add_argument(
+        "--wsname",
+        action="store",
+        default="nlpbp-test-ws",
+        help="AzureML workspace name",
+    )
+    # AzureML clustername
+    parser.add_argument(
+        "--clustername",
+        action="store",
+        default="amlcompute",
+        help="Set name of Azure cluster",
+    )
+    # Azure VM size
+    parser.add_argument(
+        "--vmsize",
+        action="store",
+        default="STANDARD_D3_V2",
+        help="Set the size of the VM either STANDARD_D3_V2",
+    )
+    # cpu or gpu
+    parser.add_argument(
+        "--dockerproc",
+        action="store",
+        default="cpu",
+        help="Base image used in docker container",
+    )
+    # Azure subscription id, when used in a pipeline, it is stored in keyvault
+    parser.add_argument(
+        "--subid",
+        action="store",
+        default="123456",
+        help="Azure Subscription ID",
+    )
+    parser.add_argument(
+        "--condafile",
+        action="store",
+        default="./nlp.yaml",
+        help="file with environment variables",
+    )
+    # AzureML experiment name
+    parser.add_argument(
+        "--expname",
+        action="store",
+        default="persistentAML",
+        help="experiment name on Azure",
+    )
+    # Azure datacenter location
+    parser.add_argument("--location", default="EastUS", help="Azure location")
+    # github repo, stored in AzureML experiment for info purposes
+    parser.add_argument(
+        "--reponame",
+        action="store",
+        default="MyGithubRepo",
+        help="GitHub repo being tested",
+    )
+    # github branch, stored in AzureML experiment for info purposes
+    parser.add_argument(
+        "--branch",
+        action="store",
+        default="--branch MyGithubBranch",
+        help=" Identify the branch test test is run on",
+    )
+    # github pull request, stored in AzureML experiment for info purposes
+    parser.add_argument(
+        "--pr",
+        action="store",
+        default="--pr PRTestRun",
+        help="If a pr triggered the test, list it here",
+    )
+
+    args = parser.parse_args()
+
+    return args
+
+
+if __name__ == "__main__":
+    logger = logging.getLogger("submit_azureml_pytest.py")
+    # logger.setLevel(logging.DEBUG)
+    # logging.basicConfig(level=logging.DEBUG)
+    args = create_arg_parser()
+
+    if args.dockerproc == "cpu":
+        from azureml.core.runconfig import DEFAULT_CPU_IMAGE
+        docker_proc_type = DEFAULT_CPU_IMAGE
+    elif args.dockerproc == "gpucuda9":
+        docker_proc_type = "mcr.microsoft.com/azureml/base-gpu:intelmpi2018.3-cuda9.0-cudnn7-ubuntu16.04"
+    else:
+        from azureml.core.runconfig import DEFAULT_GPU_IMAGE
+        docker_proc_type = DEFAULT_GPU_IMAGE
+
+    cli_auth = AzureCliAuthentication()
+
+    workspace = setup_workspace(
+        workspace_name=args.wsname,
+        subscription_id=args.subid,
+        resource_group=args.rg,
+        cli_auth=cli_auth,
+        location=args.location,
+    )
+
+    cpu_cluster = setup_persistent_compute_target(
+        workspace=workspace,
+        cluster_name=args.clustername,
+        vm_size=args.vmsize,
+        max_nodes=args.maxnodes,
+    )
+
+    run_config = create_run_config(
+        cpu_cluster=cpu_cluster,
+        docker_proc_type=docker_proc_type,
+        conda_env_file=args.condafile,
+    )
+
+    logger.info(
+        "exp: In Azure, look for experiment named {}".format(args.expname)
+    )
+
+    # create new or use existing experiment
+    experiment = Experiment(workspace=workspace, name=args.expname)
+    run = submit_experiment_to_azureml(
+        test=args.test,
+        test_folder=args.testfolder,
+        test_markers=args.testmarkers,
+        junitxml=args.junitxml,
+        run_config=run_config,
+        experiment=experiment,
+    )
+
+    # add helpful information to experiment on Azure
+    run.tag("RepoName", args.reponame)
+    run.tag("Branch", args.branch)
+    run.tag("PR", args.pr)
+    # download files from AzureML
+    run.download_files(prefix="reports", output_paths="./reports")
+    run.complete()

--- a/tests/ci/submit_azureml_pytest.py
+++ b/tests/ci/submit_azureml_pytest.py
@@ -48,9 +48,7 @@ from azureml.core.compute_target import ComputeTargetException
 from azureml.core.workspace import WorkspaceException
 
 
-def setup_workspace(
-    workspace_name, subscription_id, resource_group, cli_auth, location
-):
+def setup_workspace(workspace_name, subscription_id, resource_group, cli_auth, location):
     """
     This sets up an Azure Workspace.
     An existing Azure Workspace is used or a new one is created if needed for
@@ -99,9 +97,7 @@ def setup_workspace(
     return ws
 
 
-def setup_persistent_compute_target(
-    workspace, cluster_name, vm_size, max_nodes
-):
+def setup_persistent_compute_target(workspace, cluster_name, vm_size, max_nodes):
     """
     Set up a persistent compute target on AzureML.
     A persistent compute target runs noticeably faster than a
@@ -132,12 +128,8 @@ def setup_persistent_compute_target(
         logger.debug("setup: Found existing cluster, use it.")
     except ComputeTargetException:
         logger.debug("setup: create cluster")
-        compute_config = AmlCompute.provisioning_configuration(
-            vm_size=vm_size, max_nodes=max_nodes
-        )
-        cpu_cluster = ComputeTarget.create(
-            workspace, cluster_name, compute_config
-        )
+        compute_config = AmlCompute.provisioning_configuration(vm_size=vm_size, max_nodes=max_nodes)
+        cpu_cluster = ComputeTarget.create(workspace, cluster_name, compute_config)
     cpu_cluster.wait_for_completion(show_output=True)
     return cpu_cluster
 
@@ -198,9 +190,7 @@ def create_experiment(workspace, experiment_name):
     return exp
 
 
-def submit_experiment_to_azureml(
-    test, test_folder, test_markers, junitxml, run_config, experiment
-):
+def submit_experiment_to_azureml(test, test_folder, test_markers, junitxml, run_config, experiment):
 
     """
     Submitting the experiment to AzureML actually runs the script.
@@ -268,10 +258,7 @@ def create_arg_parser():
     )
     # test folder
     parser.add_argument(
-        "--testfolder",
-        action="store",
-        default="./tests/unit",
-        help="folder where tests are stored",
+        "--testfolder", action="store", default="./tests/unit", help="folder where tests are stored"
     )
     # pytest test markers
     parser.add_argument(
@@ -296,24 +283,15 @@ def create_arg_parser():
     )
     # Azure resource group
     parser.add_argument(
-        "--rg",
-        action="store",
-        default="nlpbp_project_resources",
-        help="Azure Resource Group",
+        "--rg", action="store", default="nlpbp_project_resources", help="Azure Resource Group"
     )
     # AzureML workspace Name
     parser.add_argument(
-        "--wsname",
-        action="store",
-        default="nlpbp-test-ws",
-        help="AzureML workspace name",
+        "--wsname", action="store", default="nlpbp-test-ws", help="AzureML workspace name"
     )
     # AzureML clustername
     parser.add_argument(
-        "--clustername",
-        action="store",
-        default="amlcompute",
-        help="Set name of Azure cluster",
+        "--clustername", action="store", default="amlcompute", help="Set name of Azure cluster"
     )
     # Azure VM size
     parser.add_argument(
@@ -324,39 +302,22 @@ def create_arg_parser():
     )
     # cpu or gpu
     parser.add_argument(
-        "--dockerproc",
-        action="store",
-        default="cpu",
-        help="Base image used in docker container",
+        "--dockerproc", action="store", default="cpu", help="Base image used in docker container"
     )
     # Azure subscription id, when used in a pipeline, it is stored in keyvault
+    parser.add_argument("--subid", action="store", default="123456", help="Azure Subscription ID")
     parser.add_argument(
-        "--subid",
-        action="store",
-        default="123456",
-        help="Azure Subscription ID",
-    )
-    parser.add_argument(
-        "--condafile",
-        action="store",
-        default="./nlp.yaml",
-        help="file with environment variables",
+        "--condafile", action="store", default="./nlp.yaml", help="file with environment variables"
     )
     # AzureML experiment name
     parser.add_argument(
-        "--expname",
-        action="store",
-        default="persistentAML",
-        help="experiment name on Azure",
+        "--expname", action="store", default="persistentAML", help="experiment name on Azure"
     )
     # Azure datacenter location
     parser.add_argument("--location", default="EastUS", help="Azure location")
     # github repo, stored in AzureML experiment for info purposes
     parser.add_argument(
-        "--reponame",
-        action="store",
-        default="MyGithubRepo",
-        help="GitHub repo being tested",
+        "--reponame", action="store", default="MyGithubRepo", help="GitHub repo being tested"
     )
     # github branch, stored in AzureML experiment for info purposes
     parser.add_argument(
@@ -386,11 +347,15 @@ if __name__ == "__main__":
 
     if args.dockerproc == "cpu":
         from azureml.core.runconfig import DEFAULT_CPU_IMAGE
+
         docker_proc_type = DEFAULT_CPU_IMAGE
     elif args.dockerproc == "gpucuda9":
-        docker_proc_type = "mcr.microsoft.com/azureml/base-gpu:intelmpi2018.3-cuda9.0-cudnn7-ubuntu16.04"
+        docker_proc_type = (
+            "mcr.microsoft.com/azureml/base-gpu:intelmpi2018.3-cuda9.0-cudnn7-ubuntu16.04"
+        )
     else:
         from azureml.core.runconfig import DEFAULT_GPU_IMAGE
+
         docker_proc_type = DEFAULT_GPU_IMAGE
 
     cli_auth = AzureCliAuthentication()
@@ -411,14 +376,10 @@ if __name__ == "__main__":
     )
 
     run_config = create_run_config(
-        cpu_cluster=cpu_cluster,
-        docker_proc_type=docker_proc_type,
-        conda_env_file=args.condafile,
+        cpu_cluster=cpu_cluster, docker_proc_type=docker_proc_type, conda_env_file=args.condafile
     )
 
-    logger.info(
-        "exp: In Azure, look for experiment named {}".format(args.expname)
-    )
+    logger.info("exp: In Azure, look for experiment named {}".format(args.expname))
 
     # create new or use existing experiment
     experiment = Experiment(workspace=workspace, name=args.expname)


### PR DESCRIPTION
### Description
- Add ability to run cpu based pytests on AzureML. Note: GPU tests are not included in this PR due to issues in the repo.
- removed ci trigger from yaml pipeline files as needed


### Related Issues


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project, as detailed in our [contribution guidelines](../CONTRIBUTING.md).
- [x] I have added tests.
- [x] I have updated the documentation accordingly.



