### PR TITLE
[BUG] in NER notebook

### DIFF
--- a/examples/named_entity_recognition/ner_wikigold_transformer.ipynb
+++ b/examples/named_entity_recognition/ner_wikigold_transformer.ipynb
@@ -306,7 +306,7 @@
     "report_splits = report.split('\\n')[-2].split()\n",
     "\n",
     "sb.glue(\"precision\", float(report_splits[2]))\n",
-    "sb.glue(\"recal\", float(report_splits[3]))\n",
+    "sb.glue(\"recall\", float(report_splits[3]))\n",
     "sb.glue(\"f1\", float(report_splits[4]))"
    ]
   }


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
https://dev.azure.com/best-practices/nlp/_build/results?buildId=14005
we get an error in the test:
```
    @pytest.mark.gpu
    @pytest.mark.integration
    def test_ner_wikigold_bert(notebooks, tmp):
        notebook_path = notebooks["ner_wikigold_transformer"]
        pm.execute_notebook(
            notebook_path,
            OUTPUT_NOTEBOOK,
            parameters={
                "CACHE_DIR": tmp
            },
            kernel_name=KERNEL_NAME,
        )
        result = sb.read_notebook(OUTPUT_NOTEBOOK).scraps.data_dict
        assert pytest.approx(result["precision"], 0.80, abs=ABS_TOL)
>       assert pytest.approx(result["recall"], 0.83, abs=ABS_TOL)
E       KeyError: 'recall'
```

### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project, as detailed in our [contribution guidelines](../CONTRIBUTING.md).
- [ ] I have added tests.
- [ ] I have updated the documentation accordingly.



