### PR TITLE
examples/embeddings/README.md is disabled to show table

### DIFF
--- a/examples/embeddings/README.md
+++ b/examples/embeddings/README.md
@@ -26,5 +26,5 @@ therefore can be very useful for  tasks like sentence similary, text classifcati
 
 
 |Notebook|Environment|Description|Dataset| Language | 
-|---|---|---|---|
+|---|---|---|---|---|
 |[Developing Word Embeddings](embedding_trainer.ipynb)|Local| A notebook shows how to learn word representation with Word2Vec, fastText and Glove|[STS Benchmark dataset](http://ixa2.si.ehu.es/stswiki/index.php/STSbenchmark#STS_benchmark_dataset_and_companion_dataset) | en |


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

As I mentioned on the title, README.md doesn't show table. I just add a table segment.

### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project, as detailed in our [contribution guidelines](../CONTRIBUTING.md).
- [x] I have added tests.
- [x] I have updated the documentation accordingly.



