### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ We strongly subscribe to the multi-language principles laid down by ["Emily Bend
 * "English isn't generic for language, despite what NLP papers might lead you to believe" 
 * "Always name the language you are working on" ([Bender rule](https://www.aclweb.org/anthology/Q18-1041/))
 
-The repository aims to support non-English languages  across all the scenarios. Pre-trianed models used in the repository such as BERT, FastText support 100+ languages out of the box. Our goal is to provide end-to-end examples in as many languages as possible. We encourage community contributions in this area.
+The repository aims to support non-English languages  across all the scenarios. Pre-trained models used in the repository such as BERT, FastText support 100+ languages out of the box. Our goal is to provide end-to-end examples in as many languages as possible. We encourage community contributions in this area.
 
 
 


### PR DESCRIPTION
### Description
Changed pre-trianed to pre-trained in README.md


### Related Issues



### Checklist:
- [x] My code follows the code style of this project, as detailed in our [contribution guidelines](../CONTRIBUTING.md).
- [ ] I have added tests.
- [x] I have updated the documentation accordingly.



