### PR TITLE
Change installation channel for pytorch to pip

### DIFF
--- a/tools/generate_conda_file.py
+++ b/tools/generate_conda_file.py
@@ -94,7 +94,7 @@ PIP_BASE = {
 }
 
 PIP_GPU = {
-    "torch": "torch>=1.0.0",
+    "torch": "torch==1.4.0",
 }
 
 PIP_DARWIN = {}

--- a/tools/generate_conda_file.py
+++ b/tools/generate_conda_file.py
@@ -52,7 +52,6 @@ CONDA_BASE = {
 
 CONDA_GPU = {
     "numba": "numba>=0.38.1",
-    "pytorch": "pytorch>=1.0.0",
     "cudatoolkit": "cudatoolkit==10.2.89",
 }
 
@@ -94,7 +93,9 @@ PIP_BASE = {
     "tensorboardX": "tensorboardX==1.8",
 }
 
-PIP_GPU = {}
+PIP_GPU = {
+    "torch": "torch>=1.0.0",
+}
 
 PIP_DARWIN = {}
 PIP_DARWIN_GPU = {}


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Change installation channel for pytorch to pip to get the right GPU enabled version
- Conda isn't resolving to the right `pytorch` channel during installation and only installing the CPU version. 


### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project, as detailed in our [contribution guidelines](../CONTRIBUTING.md).
- [ ] I have added tests.
- [ ] I have updated the documentation accordingly.



