### PR TITLE
Fixing capitalization and table headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ We hope that the open source community would contribute to the content and bring
 ## References
 The following is a list of related repositories that we like and think are useful for NLP tasks.
 
-|||
+|Repository|Description|
 |---|---|
 |[Transformers](https://github.com/huggingface/transformers)|A great PyTorch library from Hugging Face with implementations of popular transformer-based models. We've been using their package extensively in this repo and greatly appreciate their effort.|
 |[Azure Machine Learning Notebooks](https://github.com/Azure/MachineLearningNotebooks/)|ML and deep learning examples with Azure Machine Learning.|

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ The following is a list of related repositories that we like and think are usefu
 
 |||
 |---|---|
-|[transformers](https://github.com/huggingface/transformers)|A great PyTorch library from Hugging Face with implementations of popular transformer-based models. We've been using their package extensively in this repo and greatly appreciate their effort.|
+|[Transformers](https://github.com/huggingface/transformers)|A great PyTorch library from Hugging Face with implementations of popular transformer-based models. We've been using their package extensively in this repo and greatly appreciate their effort.|
 |[Azure Machine Learning Notebooks](https://github.com/Azure/MachineLearningNotebooks/)|ML and deep learning examples with Azure Machine Learning.|
 |[AzureML-BERT](https://github.com/Microsoft/AzureML-BERT)|End-to-end recipes for pre-training and fine-tuning BERT using Azure Machine Learning service.|
 |[MASS](https://github.com/microsoft/MASS)|MASS: Masked Sequence to Sequence Pre-training for Language Generation.|


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
Maybe a silly change, but I've fixed capitalization on the word "Transformers" in the references table.

I also added headers to it so it won't show any blank lines.

#### Before
![before](https://user-images.githubusercontent.com/9092284/81837122-66828080-9512-11ea-9dbc-c1d479958c7c.png)
#### After
![after](https://user-images.githubusercontent.com/9092284/81836971-2fac6a80-9512-11ea-8efd-723dfff09e36.png)