### PR TITLE
Changing default model to distilbert

### DIFF
--- a/examples/text_classification/tc_multi_languages_transformers.ipynb
+++ b/examples/text_classification/tc_multi_languages_transformers.ipynb
@@ -369,7 +369,7 @@
     "    'random_seed': 100,\n",
     "    'train_sample_ratio': 1.0,\n",
     "    'test_sample_ratio': 1.0,\n",
-    "    'model_name': 'bert-base-multilingual-cased',\n",
+    "    'model_name': 'distilbert-base-multilingual-cased',\n",
     "    'to_lower': False,\n",
     "    'cache_dir': TemporaryDirectory().name,\n",
     "    'max_len': 150,\n",


### PR DESCRIPTION
Changing default model to distilbert to allow for faster experimentation times

### Description
<!--- Describe your changes in detail -->
Changing default model to distilbert-base-multilingual-cased

<!--- Why is this change required? What problem does it solve? -->
On smaller machines such as K80, distilbert-base causes OOM issues. Using distilbert avoids this issue and also makes the notebooks run faster

### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project, as detailed in our [contribution guidelines](https://github.com/microsoft/nlp-recipes/blob/master/CONTRIBUTING.md).
- [ ] I have added tests.
- [ ] I have updated the documentation accordingly.



