### PR TITLE
Add `$schema` to `cgmanifest.json`

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -1,45 +1,46 @@
 {
-    "Registrations": [
-        {
-            "component": {
-                "type": "git",
-                "git": {
-                    "repositoryUrl": "https://github.com/facebookresearch/XLM",
-                    "commitHash": ""
-                }
-            },
-            "license": "CC BY-NC 4.0"
-        },
-        {
-            "component": {
-                "type": "git",
-                "git": {
-                    "repositoryUrl": "https://github.com/allenai/bi-att-flow",
-                    "commitHash": "e444acf13892cf62189b9eac3c7654bd83baf848"
-                }
-            },
-            "license": "Apache-2.0"
-        },
-        {
-            "component": {
-                "type": "git",
-                "git": {
-                    "repositoryUrl": "https://github.com/stanfordnlp/glove",
-                    "commitHash": "26f6e18eb117ca7b080d01acb453fd1c9742418d"
-                }
-            },
-            "license": "Apache-2.0"
-        },
-        {
-            "component": {
-                "type": "git",
-                "git": {
-                    "repositoryUrl": "https://github.com/nlpyang/PreSumm",
-                    "commitHash": "2df3312582a3a014aacbc1be810841705c67d06e"
-                }
-            },
-            "license": "MIT License"
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
+  "Registrations": [
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "repositoryUrl": "https://github.com/facebookresearch/XLM",
+          "commitHash": ""
         }
-    ],
-    "Version": 1
+      },
+      "license": "CC BY-NC 4.0"
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "repositoryUrl": "https://github.com/allenai/bi-att-flow",
+          "commitHash": "e444acf13892cf62189b9eac3c7654bd83baf848"
+        }
+      },
+      "license": "Apache-2.0"
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "repositoryUrl": "https://github.com/stanfordnlp/glove",
+          "commitHash": "26f6e18eb117ca7b080d01acb453fd1c9742418d"
+        }
+      },
+      "license": "Apache-2.0"
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "repositoryUrl": "https://github.com/nlpyang/PreSumm",
+          "commitHash": "2df3312582a3a014aacbc1be810841705c67d06e"
+        }
+      },
+      "license": "MIT License"
+    }
+  ],
+  "Version": 1
 }


### PR DESCRIPTION
This pull request adds the JSON schema for `cgmanifest.json`.

## FAQ

### Why?

A JSON schema helps you to ensure that your `cgmanifest.json` file is valid.
JSON schema validation is a build-in feature in most modern IDEs like Visual Studio and Visual Studio Code.
Most modern IDEs also provide code-completion for JSON schemas.

### How can I validate my `cgmanifest.json` file?

Most modern IDEs like Visual Studio and Visual Studio Code have a built-in feature to validate JSON files.
You can also use [this small script](https://github.com/JamieMagee/verify-cgmanifest) to validate your `cgmanifest.json` file.

### Why does it suggest camel case for the properties?

Component Detection is able to read camel case and pascal case properties.
However, the JSON schema doesn't have a case-insensitive mode.
We therefore suggest camel case as it's the most common format for JSON.

### Why is the diff so large?

To deserialize the `cgmanifest.json` file, we use [`JSON.parse()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse).
However, to serialize the JSON again we use [`prettier`](https://prettier.io/).
We found that, in general, it gave smaller diffs than the default [`JSON.stringify()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify) function.